### PR TITLE
Make run.py work with nerf_synthetic datasets

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -247,8 +247,8 @@ if __name__ == "__main__":
 		if ref_transforms:
 			testbed.fov_axis = 0
 			testbed.fov = ref_transforms["camera_angle_x"] * 180 / np.pi
-			if not len(args.screenshot_frames):
-				args.screenshot_frames = range(len(ref_transforms))
+			if not args.screenshot_frames:
+				args.screenshot_frames = range(len(ref_transforms["frames"]))
 			print(args.screenshot_frames)
 			for idx in args.screenshot_frames:
 				f = ref_transforms["frames"][int(idx)]
@@ -256,7 +256,7 @@ if __name__ == "__main__":
 				cam_matrix = f["transform_matrix"]
 				testbed.set_nerf_camera_matrix(np.matrix(cam_matrix)[:-1,:])
 				outname = os.path.join(args.screenshot_dir, os.path.basename(f["file_path"]))
-				if not outname.endswith('.png'):
+				if not os.path.splitext(outname)[1]:
 					outname = outname + '.png' # Some NeRF datasets lack the .png suffix in the dataset metadata
 				print(f"rendering {outname}")
 				image = testbed.render(args.screenshot_w or int(ref_transforms["w"]), args.screenshot_h or int(ref_transforms["h"]), args.screenshot_spp, True)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -256,6 +256,8 @@ if __name__ == "__main__":
 				cam_matrix = f["transform_matrix"]
 				testbed.set_nerf_camera_matrix(np.matrix(cam_matrix)[:-1,:])
 				outname = os.path.join(args.screenshot_dir, os.path.basename(f["file_path"]))
+				if not outname.endswith('.png'):
+					outname = outname + '.png' # Some NeRF datasets lack the .png suffix in the dataset metadata
 				print(f"rendering {outname}")
 				image = testbed.render(args.screenshot_w or int(ref_transforms["w"]), args.screenshot_h or int(ref_transforms["h"]), args.screenshot_spp, True)
 				os.makedirs(os.path.dirname(outname), exist_ok=True)


### PR DESCRIPTION
With this change, I was able to get decent results with as few as 1000 training iters with the reference NeRF synthetic Blender scenes linked in the README

```
$ python3 scripts/run.py --scene=data/nerf_synthetic/lego/ --mode=nerf --screenshot_transforms=data/nerf_synthetic/lego/transforms_test.json --screenshot_w=800 --screenshot_h=800 --screenshot_dir=data/nerf_synthetic/lego/screenshots --save_snapshot=data/nerf_synthetic/lego/snapshot.msgpack --n_steps=1000
```

The problem is that the "NeRF Blender format" lacks the file extensions in the transforms JSON metadata.  Though some NeRF projects do either supply or allow these file extensions.  This change simply provides compatibility.  

With this change, I get outputs in `screenshots` like these:
![r_0](https://user-images.githubusercontent.com/218145/149459157-28fd420d-fcdf-49fa-bd26-6465f4bdcc9a.png)

![r_1](https://user-images.githubusercontent.com/218145/149459165-ea494760-c362-4f79-aa68-398dc31be59d.png)

Perhaps we could also add that training command to the root README to make it easier to try things out?  