### PR TITLE
Delete compute capability error

### DIFF
--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1726,10 +1726,6 @@ Testbed::Testbed(ETestbedMode mode) : m_testbed_mode(mode) {
 		throw std::runtime_error{std::string{"cudaGetDeviceProperties() returned an error: "} + cudaGetErrorString(error)};
 	}
 
-	if (!((props.major * 10 + props.minor) >= 75)) {
-		throw std::runtime_error{"Turing Tensor Core operations must be run on a machine with compute capability at least 75."};
-	}
-
 	set_exposure(0);
 	set_min_level(0.f);
 	set_max_level(1.f);


### PR DESCRIPTION
Getting rid of the runtime error, makes it possible to use in sub 75 compute capabilities out of the box. This is on a GTX1070Ti:

```bash
$ ./build/testbed --scene data/sdf/armadillo.obj --no_gui
19:09:30 SUCCESS  Loaded mesh "data/sdf/armadillo.obj" file with 1 shapes.
19:09:30 SUCCESS  Built TriangleBvh: nodes=21845
19:09:30 SUCCESS  Built TriangleOctree: depth=10 nodes=209341 dual_nodes=839938. Populating dual nodes...
19:09:31 SUCCESS  Loaded mesh: triangles=99976 AABB=[min=[-0.695084,-0.825671,-0.632707], max=[0.695084,0.825671,0.632707]] after scaling=[min=[0.0865273,0.00744793,0.124301], max=[0.913473,0.992552,0.875699]]
19:09:31 INFO     Loading network config from: configs/sdf/base.json
19:09:31 INFO     GridEncoding:  Nmin=16 b=1.38191 F=2 T=2^19 L=16
Warning: FullyFusedMLP is not supported for the selected architecture 60.Falling back to CutlassMLP. For maximum performance, raise the target GPU architecture to 75+.
19:09:31 INFO     Model:         3--[HashGrid]-->32--[FullyFusedMLP(neurons=64,layers=4)]-->1
19:09:31 INFO       total_encoding_params=12196240 total_network_params=6656
19:09:36 INFO     iteration=16 loss=0.12933
19:09:42 INFO     iteration=32 loss=0.12725
19:09:47 INFO     iteration=48 loss=0.124055
19:09:53 INFO     iteration=64 loss=0.117926
19:09:58 INFO     iteration=80 loss=0.109455
19:10:03 INFO     iteration=96 loss=0.101794
```