### PR TITLE
Better optix handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 find_package(OptiX)
 # set OptiX_INSTALL_DIR via your environment if it's not found automatically
 
-if (OptiX_FOUND)
+if (OptiX_FOUND OR OptiX_INCLUDE)
 	include_directories("${OptiX_INCLUDE}")
 	add_definitions(-DNGP_OPTIX)
 else()

--- a/include/neural-graphics-primitives/triangle_bvh.cuh
+++ b/include/neural-graphics-primitives/triangle_bvh.cuh
@@ -80,6 +80,4 @@ protected:
 	TriangleBvh() {};
 };
 
-void init_optix();
-
 NGP_NAMESPACE_END

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1712,18 +1712,10 @@ Testbed::Testbed(ETestbedMode mode) : m_testbed_mode(mode) {
 		}},
 	};
 
-	init_optix();
 	reset_camera();
 
 	if (!(__CUDACC_VER_MAJOR__ > 10 || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2))) {
-		throw std::runtime_error{"Turing Tensor Core operations must be compiled with CUDA 10.2 Toolkit or later."};
-	}
-
-	cudaDeviceProp props;
-
-	cudaError_t error = cudaGetDeviceProperties(&props, 0);
-	if (error != cudaSuccess) {
-		throw std::runtime_error{std::string{"cudaGetDeviceProperties() returned an error: "} + cudaGetErrorString(error)};
+		throw std::runtime_error{"Testbed required CUDA 10.2 or later."};
 	}
 
 	set_exposure(0);


### PR DESCRIPTION
- Adds support for using the OptiX-bundled `FindOptiX.cmake` (if in module path)
- Only initializes OptiX in SDF mode (other modes don't need it)
- Falls back to `TriangleBvh::ray_intersect` if OptiX fails to initialize for any reason (related to #35)