### PR TITLE
Significant memory reduction through TCNN's new memory arena

### DIFF
--- a/include/neural-graphics-primitives/marching_cubes.h
+++ b/include/neural-graphics-primitives/marching_cubes.h
@@ -20,7 +20,7 @@ NGP_NAMESPACE_BEGIN
 
 Eigen::Vector3i get_marching_cubes_res(uint32_t res_1d, const BoundingBox &aabb);
 
-void marching_cubes_gpu(tcnn::GPUMemory<char>& scratch_memory, BoundingBox aabb, Eigen::Vector3i res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<Eigen::Vector3f>& vert_out, tcnn::GPUMemory<uint32_t>& indices_out);
+void marching_cubes_gpu(cudaStream_t stream, BoundingBox aabb, Eigen::Vector3i res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<Eigen::Vector3f>& vert_out, tcnn::GPUMemory<uint32_t>& indices_out);
 
 // computes the average of the 1ring of all verts, as homogenous coordinates
 void compute_mesh_1ring(const tcnn::GPUMemory<Eigen::Vector3f>& verts, const tcnn::GPUMemory<uint32_t>& indices, tcnn::GPUMemory<Eigen::Vector4f>& output_pos, tcnn::GPUMemory<Eigen::Vector3f>& output_normals);

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -113,7 +113,6 @@ public:
 		NerfTracer() : m_hit_counter(1), m_alive_counter(1) {}
 
 		void init_rays_from_camera(
-			tcnn::GPUMemory<char>& scratch_memory,
 			uint32_t spp,
 			uint32_t padded_output_width,
 			const Eigen::Vector2i& resolution,
@@ -159,10 +158,14 @@ public:
 			cudaStream_t stream
 		);
 
-		void enlarge(tcnn::GPUMemory<char>& scratch_memory, size_t n_elements, uint32_t padded_output_width);
+		void enlarge(size_t n_elements, uint32_t padded_output_width, cudaStream_t stream);
 		RaysNerfSoa& rays_hit() { return m_rays_hit; }
 		RaysNerfSoa& rays_init() { return m_rays[0]; }
 		uint32_t n_rays_initialized() const { return m_n_rays_initialized; }
+
+		void clear() {
+			m_scratch_alloc = {};
+		}
 
 	private:
 		RaysNerfSoa m_rays[2];
@@ -172,6 +175,7 @@ public:
 		tcnn::GPUMemory<uint32_t> m_hit_counter;
 		tcnn::GPUMemory<uint32_t> m_alive_counter;
 		uint32_t m_n_rays_initialized = 0;
+		tcnn::GPUMemoryArena::Allocation m_scratch_alloc;
 	};
 
 	class FiniteDifferenceNormalsApproximator {
@@ -422,8 +426,6 @@ public:
 
 	std::vector<CudaRenderBuffer> m_render_surfaces;
 	std::unique_ptr<CudaRenderBuffer> m_pip_render_surface;
-
-	tcnn::GPUMemory<char> m_scratch_gpu_memory;
 
 	struct Nerf {
 		NerfTracer tracer;


### PR DESCRIPTION
The `fox` scene now requires only 2.3 GB on an RTX 3090 w/ `FullyFusedMLP`.

Even when using Fp32 + `CutlassMLP` (the worst case for memory usage), `fox` and `lego/transforms_train.json` fit into 8gb.

Also fixes temporarily broken input gradients.

GPU Memory Arena
================
__tiny-cuda-nn__ now has a memory arena that can be used for efficient per-stream allocation of temporary memory. As a consequence, much of the memory that previously needed to be pre-allocated can now be allocated and released on the fly (effectively re-using it across sequential computations). This ends up reducing memory usage by over 50% in many cases. See also https://github.com/NVlabs/instant-ngp/issues/36