### PR TITLE
Fix readme typo and add docker-compose gui option for container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,14 @@
 {
     "name": "Instant NGP Dev Container",
-    "build": {
-        "context": "..",
-        "dockerfile": "Dockerfile",
-    },
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "instant-ngp",
+    "workspaceFolder": "/volume",
+    "shutdownAction": "stopCompose",
     "extensions": [
         "ms-vscode.cpptools",
         "ms-vscode.cmake-tools",
         "mutantdino.resourcemonitor",
         "ms-azuretools.vscode-docker",
-        "nvidia.nsight-vscode-edition",
-    ],
+        "nvidia.nsight-vscode-edition"
+    ]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  instant-ngp:
+    image: instantngp:latest
+    build:
+      context: ..
+      dockerfile: ./.devcontainer/Dockerfile
+    stdin_open: true
+    runtime: nvidia
+    tty: true
+    environment:
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility,graphics
+      DISPLAY: $DISPLAY
+    volumes:
+      - ../:/volume
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    working_dir: /volume
+    command: /bin/bash
+

--- a/README.md
+++ b/README.md
@@ -156,7 +156,17 @@ __A:__ Yes. See [this example](https://colab.research.google.com/drive/10TgQ4gyV
 ##
 __Q:__ Is there a [Docker container](https://www.docker.com/)?
 
-__A:__ Yes. We bundle a [Visual Studio Code development container](https://code.visualstudio.com/docs/remote/containers), the `.devcontainer/Dockerfile` of which you can also use stand-alone.
+__A:__ Yes. We bundle a [Visual Studio Code development container](https://code.visualstudio.com/docs/remote/containers), the `.devcontainer/Dockerfile` of which you can also use stand-alone. 
+
+If you want to run the container without using VSCode:
+
+```
+docker-compose -f .devcontainer/docker-compose.yml build instant-ngp
+xhost local:root
+docker-compose -f .devcontainer/docker-compose.yml run instant-ngp /bin/bash
+```
+
+Then run the build commands above as normal.
 
 ##
 __Q:__ How can I edit and train the underlying hash encoding or neural network on a new task?


### PR DESCRIPTION
It's neat that you already have a Docker container available for running in headless mode - but IMO all the cool fun stuff happens most easily in the GUI.

I managed to get GUI mode working with the docker-compose.yml file in this PR. I've only tested this on Ubuntu 21.04, with NVIDIA driver version 460.91.03  and host CUDA v11.2. It probably won't work on Windows/Mac without modifications.

Also fixed a typo - headless mode offers `--no_gui` as an argument, not `--no-gui`.