### PR TITLE
avoid unsafe casting in numpy

### DIFF
--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -260,8 +260,8 @@ if __name__ == "__main__":
 
 	# find a central point they are all looking at
 	print("computing center of attention...")
-	totw=0
-	totp=np.array([0, 0, 0])
+	totw=0.
+	totp=np.array([0., 0., 0.])
 	for f in out["frames"]:
 		mf = f["transform_matrix"][0:3,:]
 		for g in out["frames"]:


### PR DESCRIPTION
From numpy 1.7, the type of implicit casting from L:271 `totp += p*w` produces an error: 

```
TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('uint8') with casting rule 'same_kind'```

To avoid `totp` and `totw` should be initialized as `dtype('float64')`.