### PR TITLE
Misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /out
 /results
 /tmp
+/venv
 /video
 /*.json
 *.msgpack
@@ -12,4 +13,3 @@
 __pycache__
 .DS_Store
 imgui.ini
-/venv

--- a/configs/sdf/frequency.json
+++ b/configs/sdf/frequency.json
@@ -2,7 +2,10 @@
 	"parent" : "base.json",
 	"encoding": {
 		"otype": "Frequency",
-		"n_frequencies": 8
+		"n_frequencies": 10
+	},
+	"loss": {
+		"otype": "RelativeL2"
 	},
 	"optimizer": {
 		"nested": {
@@ -16,6 +19,6 @@
 		"activation": "ReLU",
 		"output_activation": "None",
 		"n_neurons": 128,
-		"n_hidden_layers": 6
+		"n_hidden_layers": 8
 	}
 }

--- a/include/neural-graphics-primitives/adam_optimizer.h
+++ b/include/neural-graphics-primitives/adam_optimizer.h
@@ -64,7 +64,7 @@ public:
 		m_state = {};
 	}
 
-	private:
+private:
 	struct State {
 		uint32_t iter = 0;
 		T first_moment = T::Zero();
@@ -130,7 +130,7 @@ public:
 		m_state = {};
 	}
 
-	private:
+private:
 	struct State {
 		uint32_t iter = 0;
 		Eigen::Vector3f first_moment = Eigen::Vector3f::Zero();

--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+
 #include <tinylogger/tinylogger.h>
 
 // Eigen uses __device__ __host__ on a bunch of defaulted constructors.
@@ -143,13 +144,20 @@ struct Ray {
 	Eigen::Vector3f d;
 };
 
+struct TrainingXForm {
+	Eigen::Matrix<float, 3, 4> start;
+	Eigen::Matrix<float, 3, 4> end;
+};
+
+enum class ECameraDistortionMode : int {
+	None,
+	Iterative,
+	FTheta,
+};
+
 struct CameraDistortion {
-	float params[4] = {};
-#ifdef __NVCC__
-	inline __host__ __device__ bool is_zero() const {
-		return params[0] == 0.0f && params[1] == 0.0f && params[2] == 0.0f && params[3] == 0.0f;
-	}
-#endif
+	ECameraDistortionMode mode = ECameraDistortionMode::None;
+	float params[7] = {};
 };
 
 #ifdef __NVCC__

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -620,6 +620,7 @@ public:
 			size_t max_size = 1 << 24;
 			bool did_generate_more_training_data = false;
 			bool generate_sdf_data_online = true;
+			float surface_offset_scale = 1.0f;
 			tcnn::GPUMemory<Eigen::Vector3f> positions;
 			tcnn::GPUMemory<Eigen::Vector3f> positions_shuffled;
 			tcnn::GPUMemory<float> distances;

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -129,6 +129,7 @@ public:
 			const Eigen::Vector2f& focal_length,
 			const Eigen::Matrix<float, 3, 4>& camera_matrix0,
 			const Eigen::Matrix<float, 3, 4>& camera_matrix1,
+			const Eigen::Vector4f& rolling_shutter,
 			Eigen::Vector2f screen_center,
 			bool snap_to_pixel_centers,
 			const BoundingBox& render_aabb,
@@ -152,7 +153,7 @@ public:
 			const BoundingBox& render_aabb,
 			const BoundingBox& train_aabb,
 			const uint32_t n_training_images,
-			const Eigen::Matrix<float, 3, 4>* training_xforms,
+			const TrainingXForm* training_xforms,
 			const Eigen::Vector2f& focal_length,
 			float cone_angle_constant,
 			const uint8_t* grid,
@@ -259,9 +260,9 @@ public:
 		const Eigen::Vector2f& screen_center,
 		cudaStream_t stream
 	);
-	void render_nerf(CudaRenderBuffer& render_buffer, const Eigen::Vector2i& max_res, const Eigen::Vector2f& focal_length, const Eigen::Matrix<float, 3, 4>& camera_matrix0, const Eigen::Matrix<float, 3, 4>& camera_matrix1, const Eigen::Vector2f& screen_center, cudaStream_t stream);
+	void render_nerf(CudaRenderBuffer& render_buffer, const Eigen::Vector2i& max_res, const Eigen::Vector2f& focal_length, const Eigen::Matrix<float, 3, 4>& camera_matrix0, const Eigen::Matrix<float, 3, 4>& camera_matrix1, const Eigen::Vector4f& rolling_shutter, const Eigen::Vector2f& screen_center, cudaStream_t stream);
 	void render_image(CudaRenderBuffer& render_buffer, cudaStream_t stream);
-	void render_frame(const Eigen::Matrix<float, 3, 4>& camera_matrix0, const Eigen::Matrix<float, 3, 4>& camera_matrix1, CudaRenderBuffer& render_buffer, bool to_srgb = true) ;
+	void render_frame(const Eigen::Matrix<float, 3, 4>& camera_matrix0, const Eigen::Matrix<float, 3, 4>& camera_matrix1, const Eigen::Vector4f& nerf_rolling_shutter, CudaRenderBuffer& render_buffer, bool to_srgb = true) ;
 	void visualize_nerf_cameras(const Eigen::Matrix<float, 4, 4>& world2proj);
 	nlohmann::json load_network_config(const filesystem::path& network_config_path);
 	void reload_network_from_file(const std::string& network_config_path);
@@ -326,6 +327,7 @@ public:
 #ifdef NGP_PYTHON
 	pybind11::dict compute_marching_cubes_mesh(Eigen::Vector3i res3d = Eigen::Vector3i::Constant(128), BoundingBox aabb = BoundingBox{Eigen::Vector3f::Zero(), Eigen::Vector3f::Ones()}, float thresh=2.5f);
 	pybind11::array_t<float> render_to_cpu(int width, int height, int spp, bool linear, float start_t, float end_t, float fps, float shutter_fraction);
+	pybind11::array_t<float> render_with_rolling_shutter_to_cpu(const Eigen::Matrix<float, 3, 4>& camera_transform_start, const Eigen::Matrix<float, 3, 4>& camera_transform_end, const Eigen::Vector4f& rolling_shutter, int width, int height, int spp, bool linear);
 	pybind11::array_t<float> screenshot(bool linear) const;
 	void override_sdf_training_data(pybind11::array_t<float> points, pybind11::array_t<float> distances);
 #endif
@@ -472,8 +474,8 @@ public:
 
 			tcnn::GPUMemory<TrainingImageMetadata> metadata_gpu;
 
-			std::vector<Eigen::Matrix<float, 3, 4>> transforms;
-			tcnn::GPUMemory<Eigen::Matrix<float, 3, 4>> transforms_gpu;
+			std::vector<TrainingXForm> transforms;
+			tcnn::GPUMemory<TrainingXForm> transforms_gpu;
 
 			std::vector<Eigen::Vector3f> cam_pos_gradient;
 			tcnn::GPUMemory<Eigen::Vector3f> cam_pos_gradient_gpu;
@@ -497,20 +499,26 @@ public:
 			float intrinsic_l2_reg = 1e-4f;
 			float exposure_l2_reg = 0.0f;
 
-			tcnn::GPUMemory<uint32_t> numsteps_counter; // number of steps each ray took
-			tcnn::GPUMemory<uint32_t> numsteps_counter_compacted; // number of steps each ray took
-			tcnn::GPUMemory<uint32_t> ray_counter;
-			tcnn::GPUMemory<float> loss;
+			struct Counters {
+				tcnn::GPUMemory<uint32_t> numsteps_counter; // number of steps each ray took
+				tcnn::GPUMemory<uint32_t> numsteps_counter_compacted; // number of steps each ray took
+				tcnn::GPUMemory<float> loss;
 
-			uint32_t rays_per_batch = 1<<12;
-			uint32_t n_rays_total = 0;
-			uint32_t measured_batch_size = 0;
-			uint32_t measured_batch_size_before_compaction = 0;
+				uint32_t rays_per_batch = 1<<12;
+				uint32_t n_rays_total = 0;
+				uint32_t measured_batch_size = 0;
+				uint32_t measured_batch_size_before_compaction = 0;
+
+				void prepare_for_training_steps(uint32_t n_training_steps, cudaStream_t stream);
+				float update_after_training(uint32_t target_batch_size, uint32_t n_training_steps, cudaStream_t stream);
+			};
+
+			Counters counters_rgb;
+
 			bool random_bg_color = true;
 			bool linear_colors = false;
 			ELossType loss_type = ELossType::L2;
 			bool snap_to_pixel_centers = true;
-
 			bool train_envmap = false;
 
 			bool optimize_distortion = false;
@@ -573,6 +581,7 @@ public:
 
 		bool visualize_cameras = false;
 		bool render_with_camera_distortion = false;
+		CameraDistortion render_distortion = {};
 
 		float rendering_min_alpha = 0.01f;
 	} m_nerf;

--- a/include/neural-graphics-primitives/trainable_buffer.cuh
+++ b/include/neural-graphics-primitives/trainable_buffer.cuh
@@ -37,7 +37,7 @@ public:
 
 	virtual ~TrainableBuffer() { }
 
-	void inference(cudaStream_t stream, const tcnn::GPUMatrixDynamic<float>& input, tcnn::GPUMatrixDynamic<float>& output) override {
+	void inference_mixed_precision(cudaStream_t stream, const tcnn::GPUMatrixDynamic<float>& input, tcnn::GPUMatrixDynamic<T>& output, bool use_inference_matrices = true) override {
 		throw std::runtime_error{"The trainable buffer does not support inference(). Its content is meant to be used externally."};
 	}
 
@@ -53,7 +53,7 @@ public:
 		const tcnn::GPUMatrixDynamic<T>& dL_doutput,
 		tcnn::GPUMatrixDynamic<float>* dL_dinput = nullptr,
 		bool use_inference_matrices = false,
-		bool compute_param_gradients = true
+		tcnn::EGradientMode param_gradients_mode = tcnn::EGradientMode::Overwrite
 	) override {
 		throw std::runtime_error{"The trainable buffer does not support backward(). Its content is meant to be used externally."};
 	}
@@ -73,6 +73,10 @@ public:
 
 	size_t n_params() const override {
 		return m_resolution.prod() * N_DIMS;
+	}
+
+	uint32_t input_width() const override {
+		return RANK;
 	}
 
 	uint32_t padded_output_width() const override {

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -37,6 +37,7 @@ def parse_args():
 
 	parser.add_argument("--nerf_compatibility", action="store_true", help="Matches parameters with original NeRF. Can cause slowness and worse results on some scenes.")
 	parser.add_argument("--test_transforms", default="", help="Path to a nerf style transforms json from which we will compute PSNR.")
+	parser.add_argument("--near_distance", default=-1, type=float, help="set the distance from the camera at which training rays start for nerf. <0 means use ngp default")
 
 	parser.add_argument("--screenshot_transforms", default="", help="Path to a nerf style transforms.json from which to save screenshots.")
 	parser.add_argument("--screenshot_frames", nargs="*", help="Which frame(s) to take screenshots of.")
@@ -140,6 +141,10 @@ if __name__ == "__main__":
 	network_stem = os.path.splitext(os.path.basename(network))[0]
 	if args.mode == "sdf":
 		setup_colored_sdf(testbed, args.scene)
+
+	if args.near_distance >= 0.0:
+		print("NeRF training ray near_distance ", args.near_distance)
+		testbed.nerf.training.near_distance = args.near_distance
 
 	if args.nerf_compatibility:
 		print(f"NeRF compatibility mode enabled")

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -521,6 +521,7 @@ PYBIND11_MODULE(pyngp, m) {
 
 	py::class_<Testbed::Sdf::Training>(sdf, "Training")
 		.def_readwrite("generate_sdf_data_online", &Testbed::Sdf::Training::generate_sdf_data_online)
+		.def_readwrite("surface_offset_scale", &Testbed::Sdf::Training::surface_offset_scale)
 		;
 
 	py::class_<Testbed::Image> image(testbed, "Image");

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -172,16 +172,16 @@ void GLTexture::resize(const Vector2i& new_size, int n_channels, bool is_8bit) {
 }
 
 GLTexture::CUDAMapping::CUDAMapping(GLuint texture_id, const Vector2i& size) : m_size{size} {
-	static bool IS_CUDA_INTEROP_SUPPORTED = true;
-	if (IS_CUDA_INTEROP_SUPPORTED) {
+	static bool s_is_cuda_interop_supported = true;
+	if (s_is_cuda_interop_supported) {
 		cudaError_t err = cudaGraphicsGLRegisterImage(&m_graphics_resource, texture_id, GL_TEXTURE_2D, cudaGraphicsRegisterFlagsSurfaceLoadStore);
 		if (err != cudaSuccess) {
-			IS_CUDA_INTEROP_SUPPORTED = false;
+			s_is_cuda_interop_supported = false;
 			cudaGetLastError(); // Reset error
 		}
 	}
 
-	if (!IS_CUDA_INTEROP_SUPPORTED) {
+	if (!s_is_cuda_interop_supported) {
 		// falling back to a regular cuda surface + CPU copy of data
 		m_cuda_surface = std::make_unique<CudaSurface2D>();
 		m_cuda_surface->resize(size);

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -384,15 +384,17 @@ void Testbed::imgui() {
 				ImGui::SliderFloat("Error overlay brightness", &m_nerf.training.error_overlay_brightness, 0.f, 1.f);
 			}
 			ImGui::SliderFloat("Density grid decay", &m_nerf.training.density_grid_decay, 0.f, 1.f,"%.4f");
-			ImGui::SliderFloat("Extrinsic L2 Reg", &m_nerf.training.extrinsic_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
-			ImGui::SliderFloat("Intrinsic L2 Reg", &m_nerf.training.intrinsic_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
-			ImGui::SliderFloat("Exposure L2 Reg", &m_nerf.training.exposure_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
+			ImGui::SliderFloat("Extrinsic L2 reg.", &m_nerf.training.extrinsic_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
+			ImGui::SliderFloat("Intrinsic L2 reg.", &m_nerf.training.intrinsic_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
+			ImGui::SliderFloat("Exposure L2 reg.", &m_nerf.training.exposure_l2_reg, 1e-8f, 0.1f, "%.6f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
 			ImGui::TreePop();
 		}
 
 		if (m_testbed_mode == ETestbedMode::Sdf && ImGui::TreeNode("SDF training options")) {
 			accum_reset |= ImGui::Checkbox("Use octree for acceleration", &m_sdf.use_triangle_octree);
 			accum_reset |= ImGui::Combo("Mesh SDF mode", (int*)&m_sdf.mesh_sdf_mode, MeshSdfModeStr);
+
+			accum_reset |= ImGui::SliderFloat("Surface offset scale", &m_sdf.training.surface_offset_scale, 0.125f, 1024.0f, "%.4f", ImGuiSliderFlags_Logarithmic | ImGuiSliderFlags_NoRoundToFormat);
 
 			if (ImGui::Checkbox("Calculate IoU", &m_sdf.calculate_iou_online)) {
 				m_sdf.iou_decay = 0;

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -225,10 +225,12 @@ void Testbed::set_view_dir(const Vector3f& dir) {
 
 void Testbed::set_camera_to_training_view(int trainview) {
 	auto old_look_at = look_at();
-	m_camera = m_smoothed_camera = m_nerf.training.dataset.xforms[trainview];
+	m_camera = m_smoothed_camera = m_nerf.training.dataset.xforms[trainview].start;
 	m_relative_focal_length = m_nerf.training.dataset.metadata[trainview].focal_length / (float)m_nerf.training.image_resolution[m_fov_axis];
 	m_scale = std::max((old_look_at - view_pos()).dot(view_dir()), 0.1f);
 	m_nerf.render_with_camera_distortion = true;
+	m_nerf.render_distortion = m_nerf.training.dataset.metadata[trainview].camera_distortion;
+	m_screen_center = Vector2f::Constant(1.0f) - m_nerf.training.dataset.metadata[0].principal_point;
 }
 
 void Testbed::reset_camera() {
@@ -297,7 +299,7 @@ void Testbed::imgui() {
 			snprintf(path_filename_buf, sizeof(path_filename_buf), "%s", get_filename_in_data_path_with_suffix(m_data_path, m_network_config_path, "_cam.json").c_str());
 		}
 		if (m_camera_path.imgui(path_filename_buf, m_frame_milliseconds, m_camera, m_slice_plane_z, m_scale, fov(), m_dof, m_bounding_radius,
-					!m_nerf.training.dataset.xforms.empty() ? m_nerf.training.dataset.xforms[0] : Matrix<float, 3, 4>::Identity())) {
+					!m_nerf.training.dataset.xforms.empty() ? m_nerf.training.dataset.xforms[0].start : Matrix<float, 3, 4>::Identity())) {
 			if (m_camera_path.m_update_cam_from_path) {
 				set_camera_from_time(m_camera_path.m_playtime);
 				if (read>1) m_smoothed_camera=m_camera;
@@ -357,7 +359,7 @@ void Testbed::imgui() {
 			ImGui::Text("Training paused");
 		}
 		if (m_testbed_mode == ETestbedMode::Nerf) {
-			ImGui::Text("Rays per batch: %d, Batch size: %d/%d", m_nerf.training.rays_per_batch, m_nerf.training.measured_batch_size, m_nerf.training.measured_batch_size_before_compaction);
+			ImGui::Text("Rays per batch: %d, Batch size: %d/%d", m_nerf.training.counters_rgb.rays_per_batch, m_nerf.training.counters_rgb.measured_batch_size, m_nerf.training.counters_rgb.measured_batch_size_before_compaction);
 		}
 		ImGui::Text("Steps: %d, Loss: %0.6f (%0.2f dB)", m_training_step, m_loss_scalar, linear_to_db(m_loss_scalar));
 		ImGui::PlotLines("loss graph", m_loss_graph, std::min(m_loss_graph_samples, 256), (m_loss_graph_samples < 256) ? 0 : (m_loss_graph_samples&255), 0, FLT_MAX, FLT_MAX, ImVec2(0, 50.f));
@@ -496,6 +498,24 @@ void Testbed::imgui() {
 
 		if (m_testbed_mode == ETestbedMode::Nerf && ImGui::TreeNode("NeRF rendering options")) {
 			accum_reset |= ImGui::Checkbox("Apply lens distortion", &m_nerf.render_with_camera_distortion);
+			if (m_nerf.render_with_camera_distortion) {
+				accum_reset |= ImGui::Combo("Distortion mode", (int*)&m_nerf.render_distortion.mode, "None\0Iterative\0F-Theta\0");
+				if (m_nerf.render_distortion.mode == ECameraDistortionMode::Iterative) {
+					accum_reset |= ImGui::InputFloat("k1", &m_nerf.render_distortion.params[0], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("k2", &m_nerf.render_distortion.params[1], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("p1", &m_nerf.render_distortion.params[2], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("p2", &m_nerf.render_distortion.params[3], 0.f, 0.f, "%.5f");
+				}
+				else if (m_nerf.render_distortion.mode == ECameraDistortionMode::FTheta) {
+					accum_reset |= ImGui::InputFloat("width", &m_nerf.render_distortion.params[5], 0.f, 0.f, "%.0f");
+					accum_reset |= ImGui::InputFloat("height", &m_nerf.render_distortion.params[6], 0.f, 0.f, "%.0f");
+					accum_reset |= ImGui::InputFloat("f_theta p0", &m_nerf.render_distortion.params[0], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("f_theta p1", &m_nerf.render_distortion.params[1], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("f_theta p2", &m_nerf.render_distortion.params[2], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("f_theta p3", &m_nerf.render_distortion.params[3], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("f_theta p4", &m_nerf.render_distortion.params[4], 0.f, 0.f, "%.5f");
+				}
+			}
 			ImGui::TreePop();
 		}
 
@@ -817,13 +837,14 @@ void Testbed::visualize_nerf_cameras(const Matrix<float, 4, 4>& world2proj) {
 	ImDrawList* list = ImGui::GetForegroundDrawList();
 	for (int i=0; i < m_nerf.training.n_images_for_training; ++i) {
 		float aspect = float(m_nerf.training.dataset.image_resolution.x())/float(m_nerf.training.dataset.image_resolution.y());
-		visualize_nerf_camera(world2proj, m_nerf.training.dataset.xforms[i], aspect, 0x40ffff40);
-		visualize_nerf_camera(world2proj, m_nerf.training.transforms[i], aspect, 0x80ffffff);
+		visualize_nerf_camera(world2proj, m_nerf.training.dataset.xforms[i].start, aspect, 0x40ffff40);
+		visualize_nerf_camera(world2proj, m_nerf.training.dataset.xforms[i].end, aspect, 0x40ffff40);
+		visualize_nerf_camera(world2proj, m_nerf.training.transforms[i].start, aspect, 0x80ffffff);
 
-		add_debug_line(world2proj, list, m_nerf.training.dataset.xforms[i].col(3), m_nerf.training.transforms[i].col(3), 0xffff40ff); // 1% loss change offset
+		add_debug_line(world2proj, list, m_nerf.training.dataset.xforms[i].start.col(3), m_nerf.training.transforms[i].start.col(3), 0xffff40ff); // 1% loss change offset
 
 		// Visualize near distance
-		add_debug_line(world2proj, list, m_nerf.training.transforms[i].col(3), m_nerf.training.transforms[i].col(3) + m_nerf.training.transforms[i].col(2) * m_nerf.training.near_distance, 0x20ffffff);
+		add_debug_line(world2proj, list, m_nerf.training.transforms[i].start.col(3), m_nerf.training.transforms[i].start.col(3) + m_nerf.training.transforms[i].start.col(2) * m_nerf.training.near_distance, 0x20ffffff);
 	}
 }
 
@@ -1242,7 +1263,7 @@ void Testbed::draw_contents() {
 
 		m_render_surfaces.front().resize(render_res);
 		if (m_max_spp <= 0 || m_render_surfaces.front().spp() < m_max_spp)
-			render_frame(m_smoothed_camera, m_smoothed_camera, m_render_surfaces.front());
+			render_frame(m_smoothed_camera, m_smoothed_camera, Eigen::Vector4f::Zero(), m_render_surfaces.front());
 
 #ifdef NGP_GUI
 		m_render_textures.front()->blit_from_cuda_mapping();
@@ -1256,7 +1277,7 @@ void Testbed::draw_contents() {
 				CameraKeyframe backup = copy_camera_to_keyframe();
 				CameraKeyframe pip_kf = m_camera_path.eval_camera_path(m_camera_path.m_playtime);
 				set_camera_from_keyframe(pip_kf);
-				render_frame(pip_kf.m(), pip_kf.m(), *m_pip_render_surface);
+				render_frame(pip_kf.m(), pip_kf.m(), Eigen::Vector4f::Zero(), *m_pip_render_surface);
 				set_camera_from_keyframe(backup);
 
 #ifdef NGP_GUI
@@ -1301,7 +1322,7 @@ void Testbed::draw_contents() {
 
 				m_visualized_dimension = i-1;
 				m_render_surfaces[i].resize(m_view_size);
-				render_frame(m_smoothed_camera, m_smoothed_camera, m_render_surfaces[i]);
+				render_frame(m_smoothed_camera, m_smoothed_camera, Eigen::Vector4f::Zero(), m_render_surfaces[i]);
 				m_render_textures[i]->blit_from_cuda_mapping();
 				++i;
 			}
@@ -1582,9 +1603,8 @@ void Testbed::reset_network() {
 	m_frame_milliseconds = 10000;
 
 	reset_accumulation();
-	m_nerf.training.rays_per_batch = 1 << 12;
-	m_nerf.training.measured_batch_size_before_compaction = 0;
-
+	m_nerf.training.counters_rgb.rays_per_batch = 1 << 12;
+	m_nerf.training.counters_rgb.measured_batch_size_before_compaction = 0;
 	m_nerf.training.n_steps_since_cam_update = 0;
 	m_nerf.training.n_steps_since_error_map_update = 0;
 	m_nerf.training.n_rays_since_error_map_update = 0;
@@ -1690,7 +1710,7 @@ void Testbed::reset_network() {
 		tlog::info()
 			<< "Density model: " << dims.n_pos
 			<< "--[" << std::string(encoding_config["otype"])
-			<< "]-->" << m_nerf_network->encoding()->num_encoded_dims()
+			<< "]-->" << m_nerf_network->encoding()->padded_output_width()
 			<< "--[" << std::string(network_config["otype"])
 			<< "(neurons=" << (int)network_config["n_neurons"] << ",layers=" << ((int)network_config["n_hidden_layers"]+2) << ")"
 			<< "]-->" << 1
@@ -1699,7 +1719,7 @@ void Testbed::reset_network() {
 		tlog::info()
 			<< "Color model:   " << n_dir_dims
 			<< "--[" << std::string(dir_encoding_config["otype"])
-			<< "]-->" << m_nerf_network->dir_encoding()->num_encoded_dims() << "+" << network_config.value("n_output_dims", 16u)
+			<< "]-->" << m_nerf_network->dir_encoding()->padded_output_width() << "+" << network_config.value("n_output_dims", 16u)
 			<< "--[" << std::string(rgb_network_config["otype"])
 			<< "(neurons=" << (int)rgb_network_config["n_neurons"] << ",layers=" << ((int)rgb_network_config["n_hidden_layers"]+2) << ")"
 			<< "]-->" << 3
@@ -1752,7 +1772,7 @@ void Testbed::reset_network() {
 		tlog::info()
 			<< "Model:         " << dims.n_input
 			<< "--[" << std::string(encoding_config["otype"])
-			<< "]-->" << m_encoding->num_encoded_dims()
+			<< "]-->" << m_encoding->padded_output_width()
 			<< "--[" << std::string(network_config["otype"])
 			<< "(neurons=" << (int)network_config["n_neurons"] << ",layers=" << ((int)network_config["n_hidden_layers"]+2) << ")"
 			<< "]-->" << dims.n_output;
@@ -1899,13 +1919,10 @@ Vector2f Testbed::calc_focal_length(const Vector2i& resolution, int fov_axis, fl
 Vector2f Testbed::render_screen_center() const {
 	// see pixel_to_ray for how screen center is used; 0.5,0.5 is 'normal'. we flip so that it becomes the point in the original image we want to center on.
 	auto screen_center = m_screen_center;
-	if (m_nerf.render_with_camera_distortion && !m_nerf.training.dataset.metadata.empty()) {
-		screen_center -= m_nerf.training.dataset.metadata[0].principal_point - Vector2f::Constant(0.5f);
-	}
 	return {(0.5f-screen_center.x())*m_zoom + 0.5f, (0.5-screen_center.y())*m_zoom + 0.5f};
 }
 
-void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matrix<float, 3, 4>& camera_matrix1, CudaRenderBuffer& render_buffer, bool to_srgb) {
+void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matrix<float, 3, 4>& camera_matrix1, const Vector4f& nerf_rolling_shutter, CudaRenderBuffer& render_buffer, bool to_srgb) {
 	Vector2i max_res = m_window_res.cwiseMax(render_buffer.resolution());
 
 	render_buffer.clear_frame_buffer(m_inference_stream);
@@ -1916,7 +1933,7 @@ void Testbed::render_frame(const Matrix<float, 3, 4>& camera_matrix0, const Matr
 	switch (m_testbed_mode) {
 		case ETestbedMode::Nerf:
 			if (!m_render_ground_truth) {
-				render_nerf(render_buffer, max_res, focal_length, camera_matrix0, camera_matrix1, screen_center, m_inference_stream);
+				render_nerf(render_buffer, max_res, focal_length, camera_matrix0, camera_matrix1, nerf_rolling_shutter, screen_center, m_inference_stream);
 			}
 			break;
 		case ETestbedMode::Sdf:
@@ -2064,7 +2081,7 @@ void Testbed::determine_autofocus_target_from_pixel(const Vector2i& focus_pixel)
 		m_autofocus = false;
 		m_slice_plane_z = 0.0f;
 
-		render_frame(m_smoothed_camera, m_smoothed_camera, m_windowless_render_surface, false);
+		render_frame(m_smoothed_camera, m_smoothed_camera, Eigen::Vector4f::Zero(), m_windowless_render_surface, false);
 		CUDA_CHECK_THROW(cudaDeviceSynchronize());
 		std::vector<float> depth_cpu(depth_render_res.y() * depth_render_res.x() * 4);
 		CUDA_CHECK_THROW(cudaMemcpy2DFromArray(depth_cpu.data(), depth_render_res.x() * sizeof(float) * 4, m_windowless_render_surface.surface_provider().array(), 0, 0, depth_render_res.x() * sizeof(float) * 4, depth_render_res.y(), cudaMemcpyDeviceToHost));
@@ -2167,9 +2184,9 @@ void Testbed::save_snapshot(const std::string& filepath_string, bool include_opt
 	m_network_config["snapshot"]["loss"] = m_loss_scalar;
 
 	if (m_testbed_mode == ETestbedMode::Nerf) {
-		m_network_config["snapshot"]["nerf"]["rays_per_batch"] = m_nerf.training.rays_per_batch;
-		m_network_config["snapshot"]["nerf"]["measured_batch_size"] = m_nerf.training.measured_batch_size;
-		m_network_config["snapshot"]["nerf"]["measured_batch_size_before_compaction"] = m_nerf.training.measured_batch_size_before_compaction;
+		m_network_config["snapshot"]["nerf"]["rgb"]["rays_per_batch"] = m_nerf.training.counters_rgb.rays_per_batch;
+		m_network_config["snapshot"]["nerf"]["rgb"]["measured_batch_size"] = m_nerf.training.counters_rgb.measured_batch_size;
+		m_network_config["snapshot"]["nerf"]["rgb"]["measured_batch_size_before_compaction"] = m_nerf.training.counters_rgb.measured_batch_size_before_compaction;
 		m_network_config["snapshot"]["nerf"]["dataset"] = m_nerf.training.dataset;
 	}
 
@@ -2188,10 +2205,9 @@ void Testbed::load_snapshot(const std::string& filepath_string) {
 	m_network_config = config;
 
 	if (m_testbed_mode == ETestbedMode::Nerf) {
-		m_nerf.training.rays_per_batch = m_network_config["snapshot"]["nerf"]["rays_per_batch"];
-		m_nerf.training.measured_batch_size = m_network_config["snapshot"]["nerf"]["measured_batch_size"];
-		m_nerf.training.measured_batch_size_before_compaction = m_network_config["snapshot"]["nerf"]["measured_batch_size_before_compaction"];
-
+		m_nerf.training.counters_rgb.rays_per_batch = m_network_config["snapshot"]["nerf"]["rgb"]["rays_per_batch"];
+		m_nerf.training.counters_rgb.measured_batch_size = m_network_config["snapshot"]["nerf"]["rgb"]["measured_batch_size"];
+		m_nerf.training.counters_rgb.measured_batch_size_before_compaction = m_network_config["snapshot"]["nerf"]["rgb"]["measured_batch_size_before_compaction"];
 		// If we haven't got a nerf dataset loaded, load dataset metadata from the snapshot
 		// and render using just that.
 		if (m_data_path.empty() && m_network_config["snapshot"]["nerf"].contains("dataset")) {

--- a/src/testbed_sdf.cu
+++ b/src/testbed_sdf.cu
@@ -1058,7 +1058,7 @@ void Testbed::generate_training_samples_sdf(Vector3f* positions, float* distance
 	// If we have an octree, generate uniform samples within that octree.
 	// Otherwise, at least confine uniform samples to the AABB.
 	// (For the uniform_only case, we always use the AABB, then the IoU kernel checks against the octree later)
-	float stddev = m_bounding_radius/1024.0f ; // * 8.f;
+	float stddev = m_bounding_radius/1024.0f * m_sdf.training.surface_offset_scale;
 	if (!uniform_only && (m_sdf.uses_takikawa_encoding || m_sdf.use_triangle_octree)) {
 		linear_kernel(uniform_octree_sample_kernel, 0, stream,
 			n_to_generate_uniform,


### PR DESCRIPTION
- Improved the bundled frequency-encoding SDF config (`sdf/frequency.json`) and adds a parameter to control the training data spread around surfaces. Freq-encoding-based SDFs train much better when this parameter is increased to 8x (from the default of 1x)
- Added f-theta lens models and rolling shutter support for NeRF training data (courtesy of @mmalex)
- Updated __tiny-cuda-nn__ with latest Encoding/Network unification changes. These provide a backbone for e.g. depth supervision from RGB-D cameras (or similar) to get rid of floaters.
- Various small additions