### PR TITLE
SDF mode should set 0.0 thresh to save mesh

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -292,7 +292,12 @@ if __name__ == "__main__":
 	if args.save_mesh:
 		res = args.marching_cubes_res or 256
 		print(f"Generating mesh via marching cubes and saving to {args.save_mesh}. Resolution=[{res},{res},{res}]")
-		testbed.compute_and_save_marching_cubes_mesh(args.save_mesh, [res, res, res])
+		if args.mode == "sdf":
+			# thresh is 2.5 by default which works for nerf but produces 0 verts/indices for sdf
+			# 0.0 thresh should be set for sdf mode
+			testbed.compute_and_save_marching_cubes_mesh(args.save_mesh, [res, res, res], thresh=0.0)
+		elif args.mode == "nerf":
+			testbed.compute_and_save_marching_cubes_mesh(args.save_mesh, [res, res, res])
 
 	if args.width:
 		if ref_transforms:


### PR DESCRIPTION
following up on this discussion:
https://github.com/NVlabs/instant-ngp/discussions/326#discussioncomment-2361930

it is currently impossible to use run.py, in SDF mode to save meshes...

as the default thresh arg value is set to 2.5 which seems to work for NeRF mode but doesn't for SDF mode.
this change passes 0.0 for thresh arg in SDF mode.