### PR TITLE
fix problem that python cannot render image by using GIL again in python's render func

### DIFF
--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -331,7 +331,7 @@ PYBIND11_MODULE(pyngp, m) {
 		)
 		.def("want_repl", &Testbed::want_repl, "returns true if the user clicked the 'I want a repl' button")
 		.def("frame", &Testbed::frame, py::call_guard<py::gil_scoped_release>(), "Process a single frame. Renders if a window was previously created.")
-		.def("render", &Testbed::render_to_cpu, py::call_guard<py::gil_scoped_release>(), "Renders an image at the requested resolution. Does not require a window.",
+		.def("render", &Testbed::render_to_cpu, "Renders an image at the requested resolution. Does not require a window.",
 			py::arg("width") = 1920,
 			py::arg("height") = 1080,
 			py::arg("spp") = 1,


### PR DESCRIPTION
I recently found that the latest commit introduced a new problem. It causes `segmentation fault` when we are trying to render images to compute PSNR. I found that it can be simply avoided by using GIL again.
To reproduce the problem, just compile the latest commit (5caa5b91), and run the following command:
``` bash
CUDA_VISIBLE_DEVICES=0 python ./scripts/run.py --mode nerf --scene dataset_files/nerf_synthetic/lego --save_mesh mesh_lego.ply --test_transforms dataset_files/nerf_synthetic/lego/transforms_test.json --n_steps 1000
```
It will be like that:
``` 
Evaluating test transforms from  dataset_files/nerf_synthetic/lego/transforms_test.json
Rendering test frame:   0%|                                                                                                      | 0/200 [00:00<?, ?images/s]
[1]    1084091 segmentation fault (core dumped)  CUDA_VISIBLE_DEVICES=0 python ./scripts/run.py --mode nerf --scene       1000
```
After using the GIL again, this problem is resolved, and we got something like that:
```
Evaluating test transforms from  dataset_files/nerf_synthetic/lego/transforms_test.json
Rendering test frame: 100%|███████████████████████████████████████████████████████████████████████████████████| 200/200 [01:21<00:00,  2.44images/s, psnr=32]
PSNR=32.02128059555034 [min=25.2066873076208 max=33.821235749840014] SSIM=0.8422696429491043
Generating mesh via marching cubes and saving to mesh_lego.ply. Resolution=[256,256,256]
16:54:53 INFO     #vertices=278858 #triangles=555264
```
I don't know why, but it just works.