### PR TITLE
fix segmentation fault by using GIL again for python's set_image func

### DIFF
--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -539,7 +539,7 @@ PYBIND11_MODULE(pyngp, m) {
 			"Set up the camera extrinsics for the given training image index, from the given 3x4 transformation matrix."
 		)
 		.def("get_camera_extrinsics", &Testbed::Nerf::Training::get_camera_extrinsics, py::arg("frame_idx"), "return the 3x4 transformation matrix of given training frame")
-		.def("set_image", &Testbed::Nerf::Training::set_image, py::call_guard<py::gil_scoped_release>(),
+		.def("set_image", &Testbed::Nerf::Training::set_image,
 			py::arg("frame_idx"),
 			py::arg("img"),
 			"set one of the training images. must be a floating point numpy array of (H,W,C) with 4 channels; linear color space; W and H must match image size of the rest of the dataset"

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -2282,6 +2282,7 @@ void Testbed::load_nerf() {
 	m_nerf.training.cam_pos_gradient.resize(m_nerf.training.dataset.n_images, Vector3f::Zero());
 	m_nerf.training.cam_pos_gradient_gpu.resize_and_copy_from_host(m_nerf.training.cam_pos_gradient);
 
+	m_nerf.training.cam_exposure.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Array3f>(1e-3f));
 	m_nerf.training.cam_pos_offset.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Vector3f>(1e-4f));
 	m_nerf.training.cam_rot_offset.resize(m_nerf.training.dataset.n_images, RotationAdamOptimizer(1e-4f));
 	m_nerf.training.cam_focal_length_offset = AdamOptimizer<Vector2f>(1e-5f);


### PR DESCRIPTION
It's similar to [a previous bugfix](https://github.com/NVlabs/instant-ngp/pull/466), I also find that if we release the GIL for `set_image` function, it will cause a segmentation fault error. So I remove `py::call_guard<py::gil_scoped_release>()` for this function.