### PR TITLE
fix two segfault errors and one warp-out-of-range-address error when we use `create_empty_nerf_dataset()`, `set_image()` and `set_camera_extrinsics()`

### DIFF
--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -539,7 +539,7 @@ PYBIND11_MODULE(pyngp, m) {
 			"Set up the camera extrinsics for the given training image index, from the given 3x4 transformation matrix."
 		)
 		.def("get_camera_extrinsics", &Testbed::Nerf::Training::get_camera_extrinsics, py::arg("frame_idx"), "return the 3x4 transformation matrix of given training frame")
-		.def("set_image", &Testbed::Nerf::Training::set_image, py::call_guard<py::gil_scoped_release>(),
+		.def("set_image", &Testbed::Nerf::Training::set_image,
 			py::arg("frame_idx"),
 			py::arg("img"),
 			"set one of the training images. must be a floating point numpy array of (H,W,C) with 4 channels; linear color space; W and H must match image size of the rest of the dataset"

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -2282,6 +2282,7 @@ void Testbed::load_nerf() {
 	m_nerf.training.cam_pos_gradient.resize(m_nerf.training.dataset.n_images, Vector3f::Zero());
 	m_nerf.training.cam_pos_gradient_gpu.resize_and_copy_from_host(m_nerf.training.cam_pos_gradient);
 
+	m_nerf.training.cam_exposure.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Array3f>(1e-3f));
 	m_nerf.training.cam_pos_offset.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Vector3f>(1e-4f));
 	m_nerf.training.cam_rot_offset.resize(m_nerf.training.dataset.n_images, RotationAdamOptimizer(1e-4f));
 	m_nerf.training.cam_focal_length_offset = AdamOptimizer<Vector2f>(1e-5f);


### PR DESCRIPTION
This pull request fixes three fatal errors when we try to use `create_empty_nerf_dataset()` and its related utils funcs (`set_image()` and `set_camera_extrinsics()`) to create training dataset from numpy ndarray instead of loading from files.

**Related to `set_image()` function:**
The first is similar to [a previous bugfix](https://github.com/NVlabs/instant-ngp/pull/466), I also find that if we release the GIL for `set_image()` function, it will cause a segmentation fault error. So I remove `py::call_guard<py::gil_scoped_release>()` for this function.

**Related to `set_camera_extrinsics()` function:**
Another is also a segfault [issue](https://github.com/NVlabs/instant-ngp/issues/484). I notice that we can't correctly use `set_camera_extrinsics()` because it raises a segfault error when we want to execute `cam_exposure[frame_idx].reset_state()`, this is because we haven't allocated the memory for variable `cam_exposure`, so I add `m_nerf.training.cam_exposure.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Array3f>(1e-3f))` to `Testbed::load_nerf()` function to allocate its memory.  it fixes #484

**Related to `create_empty_nerf_dataset()` function:**
However, after changing the above, we may still have a warp-out-of-range-address error when we sample training rays from the images, e.g. the `generate_training_samples_nerf()` kernel will raise the error. I find that `m_nerf.training.n_images_for_training` variable have a wrong value of zero, which is assigned zero in the `create_empty_nerf_dataset()` function. Notice that `load_nerf()` have already assigned a correct value for the variable, we shouldn't reassign the value again. So I remove `m_nerf.training.n_images_for_training = 0`, and it finally works correctly.

After these modifications, we can create dataset from numpy ndarray, and the training process runs smoothly.

I hope you'd like it.