### PR TITLE
Remove unused metric map saving feature in compute_error function

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -267,9 +267,4 @@ def compute_error(metric, img, ref, metric_map_filename=None):
 	if len(metric_map.shape) == 3:
 		metric_map = np.mean(metric_map, axis=2)
 	mean = np.mean(metric_map)
-	if metric_map_filename:
-		if not metric_map_filename.suffix.lower() == ".exr":
-			index_map = np.clip(255.0 * np.squeeze(metric_map), 0, 255)
-			metric_map = flip.utils.CHWtoHWC(flip.utils.index2color(index_map, flip.utils.get_magma_map()))
-		exr.write(data=metric_map, filename=str(metric_map_filename))
 	return mean

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -261,7 +261,7 @@ def compute_error_img(metric, img, ref):
 
 	raise ValueError(f"Unknown metric: {metric}.")
 
-def compute_error(metric, img, ref, metric_map_filename=None):
+def compute_error(metric, img, ref):
 	metric_map = compute_error_img(metric, img, ref)
 	metric_map[np.logical_not(np.isfinite(metric_map))] = 0
 	if len(metric_map.shape) == 3:


### PR DESCRIPTION
I believe this should have been done by 986af675e29ac1b488c8b9f21284ebf55abccae7

PyExr is no longer being imported, so it will just throw an error if you try to provide an argument for metric_map_filename