### PR TITLE
:sparkles: add 360 and ortho cameras

### DIFF
--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -81,6 +81,12 @@ enum class ERenderMode : int {
 };
 static constexpr const char* RenderModeStr = "AO\0Shade\0Normals\0Positions\0Depth\0Distortion\0Cost\0Slice\0\0";
 
+enum class ECameraMode : int {
+    Perspective,
+    Orthographic,
+    Environment
+};
+
 enum class ERandomMode : int {
 	Random,
 	Halton,

--- a/include/neural-graphics-primitives/common_device.cuh
+++ b/include/neural-graphics-primitives/common_device.cuh
@@ -261,6 +261,7 @@ inline __host__ __device__ Ray pixel_to_ray(
 	bool snap_to_pixel_centers = false,
 	float focus_z = 1.0f,
 	float dof = 0.0f,
+    ECameraMode camera_mode = ECameraMode::Perspective,
 	const CameraDistortion& camera_distortion = {},
 	const float* __restrict__ distortion_data = nullptr,
 	const Eigen::Vector2i distortion_resolution = Eigen::Vector2i::Zero()
@@ -269,30 +270,54 @@ inline __host__ __device__ Ray pixel_to_ray(
 	Eigen::Vector2f uv = (pixel.cast<float>() + offset).cwiseQuotient(resolution.cast<float>());
 
 	Eigen::Vector3f dir;
-	if (camera_distortion.mode == ECameraDistortionMode::FTheta) {
-		dir = f_theta_undistortion(uv - screen_center, camera_distortion.params, {1000.f, 0.f, 0.f});
-		if (dir.x() == 1000.f) {
-			return {{1000.f, 0.f, 0.f}, {0.f, 0.f, 1.f}}; // return a point outside the aabb so the pixel is not rendered
-		}
-	} else {
-		dir = {
-			(uv.x() - screen_center.x()) * (float)resolution.x() / focal_length.x(),
-			(uv.y() - screen_center.y()) * (float)resolution.y() / focal_length.y(),
-			1.0f
-		};
-		if (camera_distortion.mode == ECameraDistortionMode::Iterative) {
-			iterative_camera_undistortion(camera_distortion.params, &dir.x(), &dir.y());
-		}
-	}
-	if (distortion_data) {
-		dir.head<2>() += read_image<2>(distortion_data, distortion_resolution, uv);
-	}
+    Eigen::Vector3f head_pos;
+    if(camera_mode == ECameraMode::Orthographic){
+        dir = {0.f, 0.f, 1.f}; // Camera forward
+        head_pos = {
+            (uv.x() - screen_center.x()) * (float)resolution.x() / focal_length.x(),
+            (uv.y() - screen_center.y()) * (float)resolution.y() / focal_length.y(),
+            0.0f
+        };
+    }
+    else if(camera_mode == ECameraMode::Environment){
+        // Camera convention: XYZ <-> Right Down Front
+        head_pos = {0.f, 0.f, 0.f};
+        const float phi = (uv.y()-0.5) * M_PI;
+        const float theta = (uv.x()-0.5) * 2.0 * M_PI;
+        const float cos_phi = std::cos(phi);
+        dir = {
+            cos_phi*std::sin(theta),
+            std::sin(phi),
+            cos_phi*std::cos(theta)
+        };
+    }
+    else { // Perspective
+        if (camera_distortion.mode == ECameraDistortionMode::FTheta) {
+            dir = f_theta_undistortion(uv - screen_center, camera_distortion.params, {1000.f, 0.f, 0.f});
+            if (dir.x() == 1000.f) {
+                return {{1000.f, 0.f, 0.f}, {0.f, 0.f, 1.f}}; // return a point outside the aabb so the pixel is not rendered
+            }
+        } else {
+            dir = {
+                (uv.x() - screen_center.x()) * (float)resolution.x() / focal_length.x(),
+                (uv.y() - screen_center.y()) * (float)resolution.y() / focal_length.y(),
+                1.0f
+            };
+            if (camera_distortion.mode == ECameraDistortionMode::Iterative) {
+                iterative_camera_undistortion(camera_distortion.params, &dir.x(), &dir.y());
+            }
+        }
+        if (distortion_data) {
+		    dir.head<2>() += read_image<2>(distortion_data, distortion_resolution, uv);
+	    }
 
-	Eigen::Vector3f head_pos = {parallax_shift.x(), parallax_shift.y(), 0.f};
-	dir -= head_pos / parallax_shift.z(); // we could use focus_z here in the denominator. for now, we pack m_scale in here.
-	dir = camera_matrix.block<3, 3>(0, 0) * dir;
+        head_pos = {parallax_shift.x(), parallax_shift.y(), 0.f};
+        dir -= head_pos / parallax_shift.z(); // we could use focus_z here in the denominator. for now, we pack m_scale in here.
+    }
 
-	Eigen::Vector3f origin = camera_matrix.block<3, 3>(0, 0) * head_pos + camera_matrix.col(3);
+    dir = camera_matrix.block<3, 3>(0, 0) * dir;
+    Eigen::Vector3f origin = camera_matrix.block<3, 3>(0, 0) * head_pos + camera_matrix.col(3);
+
 	if (dof == 0.0f) {
 		return {origin, dir};
 	}
@@ -362,6 +387,7 @@ inline __host__ __device__ Eigen::Vector2f motion_vector_3d(
 		snap_to_pixel_centers,
 		1.0f,
 		0.0f,
+        ECameraMode::Perspective,
 		camera_distortion,
 		nullptr,
 		Eigen::Vector2i::Zero()

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -156,6 +156,7 @@ public:
 			int show_accel,
 			float cone_angle_constant,
 			ERenderMode render_mode,
+            ECameraMode camera_mode,
 			cudaStream_t stream
 		);
 
@@ -464,6 +465,7 @@ public:
 	float m_bounding_radius = 1;
 	float m_exposure = 0.f;
 
+    ECameraMode m_camera_mode = ECameraMode::Perspective;
 	ERenderMode m_render_mode = ERenderMode::Shade;
 	EMeshRenderMode m_mesh_render_mode = EMeshRenderMode::VertexNormals;
 

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -238,6 +238,13 @@ PYBIND11_MODULE(pyngp, m) {
 		.value("Slice", ERenderMode::Slice)
 		.export_values();
 
+    py::enum_<ECameraMode>(m, "CameraMode")
+		.value("Perspective", ECameraMode::Perspective)
+        .value("Orthographic", ECameraMode::Orthographic)
+		.value("Environment", ECameraMode::Environment)
+		.export_values();
+
+
 	py::enum_<ERandomMode>(m, "RandomMode")
 		.value("Random", ERandomMode::Random)
 		.value("Halton", ERandomMode::Halton)
@@ -412,6 +419,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("shall_train_network", &Testbed::m_train_network)
 		.def_readwrite("render_groundtruth", &Testbed::m_render_ground_truth)
 		.def_readwrite("render_mode", &Testbed::m_render_mode)
+        .def_readwrite("camera_mode", &Testbed::m_camera_mode)
 		.def_readwrite("slice_plane_z", &Testbed::m_slice_plane_z)
 		.def_readwrite("dof", &Testbed::m_dof)
 		.def_readwrite("autofocus", &Testbed::m_autofocus)

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -1780,7 +1780,8 @@ __global__ void init_rays_with_payload_kernel_nerf(
 	float* __restrict__ depthbuffer,
 	const float* __restrict__ distortion_data,
 	const Vector2i distortion_resolution,
-	ERenderMode render_mode
+	ERenderMode render_mode,
+    ECameraMode camera_mode
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
@@ -1811,6 +1812,7 @@ __global__ void init_rays_with_payload_kernel_nerf(
 		snap_to_pixel_centers,
 		plane_z,
 		dof,
+        camera_mode,
 		camera_distortion,
 		distortion_data,
 		distortion_resolution
@@ -1960,6 +1962,7 @@ void Testbed::NerfTracer::init_rays_from_camera(
 	int show_accel,
 	float cone_angle_constant,
 	ERenderMode render_mode,
+    ECameraMode camera_mode,
 	cudaStream_t stream
 ) {
 	// Make sure we have enough memory reserved to render at the requested resolution
@@ -1990,7 +1993,8 @@ void Testbed::NerfTracer::init_rays_from_camera(
 		depth_buffer,
 		distortion_data,
 		distortion_resolution,
-		render_mode
+		render_mode,
+        camera_mode
 	);
 
 	m_n_rays_initialized = resolution.x() * resolution.y();
@@ -2253,6 +2257,7 @@ void Testbed::render_nerf(CudaRenderBuffer& render_buffer, const Vector2i& max_r
 		m_nerf.show_accel,
 		m_nerf.cone_angle_constant,
 		render_mode,
+        m_camera_mode,
 		stream
 	);
 


### PR DESCRIPTION
Update 'pixel_to_ray' method to handle orthographic and environment (360°) cameras