### PR TITLE
Handling exceptional case for rotmat function

### DIFF
--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -128,8 +128,11 @@ def qvec2rotmat(qvec):
 
 def rotmat(a, b):
 	a, b = a / np.linalg.norm(a), b / np.linalg.norm(b)
-	v = np.cross(a, b)
 	c = np.dot(a, b)
+	# handle exception for the opposite direction input
+	if(c < -1 + 1e-10):
+		return -np.eye(3)
+	v = np.cross(a, b)
 	s = np.linalg.norm(v)
 	kmat = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
 	return np.eye(3) + kmat + kmat.dot(kmat) * ((1 - c) / (s ** 2 + 1e-10))

--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -128,11 +128,11 @@ def qvec2rotmat(qvec):
 
 def rotmat(a, b):
 	a, b = a / np.linalg.norm(a), b / np.linalg.norm(b)
+	v = np.cross(a, b)
 	c = np.dot(a, b)
 	# handle exception for the opposite direction input
-	if(c < -1 + 1e-10):
-		return -np.eye(3)
-	v = np.cross(a, b)
+	if c < -1 + 1e-10:
+		return rotmat(a + np.random.uniform(-1e-2, 1e-2, 3), b)
 	s = np.linalg.norm(v)
 	kmat = np.array([[0, -v[2], v[1]], [v[2], 0, -v[0]], [-v[1], v[0], 0]])
 	return np.eye(3) + kmat + kmat.dot(kmat) * ((1 - c) / (s ** 2 + 1e-10))


### PR DESCRIPTION
I just notice that the rotmat function would return identity matrix if input vectors have opposite directions because the cross of two opposite directional vector results in zero in numpy.

So, I add an exception handling for the case.
you can check the correction at my [colab](https://colab.research.google.com/drive/18V0siUhfIT8hweRrT4r0KJXGlOx_g3uE?usp=sharing).