### PR TITLE
Fix depth code. Add depth loss control and dataset

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -560,6 +560,7 @@ public:
 			bool random_bg_color = true;
 			bool linear_colors = false;
 			ELossType loss_type = ELossType::L2;
+			ELossType depth_loss_type = ELossType::L1;
 			bool snap_to_pixel_centers = true;
 			bool train_envmap = false;
 

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -536,6 +536,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("n_images_for_training", &Testbed::Nerf::Training::n_images_for_training)
 		.def_readwrite("linear_colors", &Testbed::Nerf::Training::linear_colors)
 		.def_readwrite("loss_type", &Testbed::Nerf::Training::loss_type)
+		.def_readwrite("depth_loss_type", &Testbed::Nerf::Training::depth_loss_type)
 		.def_readwrite("snap_to_pixel_centers", &Testbed::Nerf::Training::snap_to_pixel_centers)
 		.def_readwrite("optimize_extrinsics", &Testbed::Nerf::Training::optimize_extrinsics)
 		.def_readwrite("optimize_extra_dims", &Testbed::Nerf::Training::optimize_extra_dims)

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -475,6 +475,7 @@ void Testbed::imgui() {
 			ImGui::SliderFloat("Near distance", &m_nerf.training.near_distance, 0.0f, 1.0f);
 			accum_reset |= ImGui::Checkbox("Linear colors", &m_nerf.training.linear_colors);
 			ImGui::Combo("Loss", (int*)&m_nerf.training.loss_type, LossTypeStr);
+			ImGui::Combo("Depth Loss", (int*)&m_nerf.training.depth_loss_type, LossTypeStr);
 			ImGui::Combo("RGB activation", (int*)&m_nerf.rgb_activation, NerfActivationStr);
 			ImGui::Combo("Density activation", (int*)&m_nerf.density_activation, NerfActivationStr);
 			ImGui::SliderFloat("Cone angle", &m_nerf.cone_angle_constant, 0.0f, 1.0f/128.0f);


### PR DESCRIPTION
Depth supervision code: 
https://github.com/NVlabs/instant-ngp/blob/3fa15bf7e1c8a4bed586afde3e0bdf5074a4b7c6/src/testbed_nerf.cu#L1405

The two values "depth_ray" and "depth_target" are not comparable. depth_ray is the expected length of the ray, "depth_target" is the z coordinate of the pixel from the camera's frame. 

I also added a combo box  to allow the user to choose which loss they want on the depth. Default is L1 because I found it works better to produce crisper images - probably because it forces the weights to be sparse. 
![image](https://user-images.githubusercontent.com/29726242/174932052-3397884d-947d-46ad-a03e-f931fd0f00a4.png)

Lastly, I added a minimal nerf dataset "bluebell" with depth supervision for testing. I used this dataset previously in my [work](https://arxiv.org/abs/2204.10516) and it might be useful to bootstrap playing with depth. 