### PR TITLE
Added buttons for previous, next and reset, and keys [ for previous a…

### DIFF
--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -130,7 +130,7 @@ inline void to_json(nlohmann::json& j, const TrainingXForm& x) {
 
 inline void to_json(nlohmann::json& j, const NerfDataset& dataset) {
 	j["n_images"] = dataset.n_images;
-        j["paths"] = dataset.paths;
+	j["paths"] = dataset.paths;
 	for (size_t i = 0; i < dataset.n_images; ++i) {
 		j["metadata"].emplace_back();
 		j["xforms"].emplace_back();
@@ -179,8 +179,8 @@ inline void from_json(const nlohmann::json& j, NerfDataset& dataset) {
 		if (j.contains("paths")) {
 			dataset.paths.push_back(j["paths"].at(i));
 		} else {
- 			dataset.paths.push_back(std::string(""));
-                }
+			dataset.paths.push_back(std::string(""));
+		}
 	}
 
 	dataset.render_aabb = j.at("render_aabb");

--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -157,6 +157,8 @@ inline void from_json(const nlohmann::json& j, NerfDataset& dataset) {
 	dataset.n_images = j.at("n_images");
 	dataset.metadata.resize(dataset.n_images);
 	dataset.xforms.resize(dataset.n_images);
+	dataset.paths.resize(dataset.n_images, "");
+	if (j.contains("paths")) dataset.paths = j["paths"].get<std::vector<std::string>>();
 
 	for (size_t i = 0; i < dataset.n_images; ++i) {
 		// read global defaults first
@@ -175,11 +177,6 @@ inline void from_json(const nlohmann::json& j, NerfDataset& dataset) {
 			from_json(ji.at("principal_point"), dataset.metadata[i].principal_point);
 			from_json(ji.at("rolling_shutter"), dataset.metadata[i].rolling_shutter);
 			from_json(ji.at("camera_distortion"), dataset.metadata[i].camera_distortion);
-		}
-		if (j.contains("paths")) {
-			dataset.paths.push_back(j["paths"].at(i));
-		} else {
-			dataset.paths.push_back(std::string(""));
 		}
 	}
 

--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -130,6 +130,7 @@ inline void to_json(nlohmann::json& j, const TrainingXForm& x) {
 
 inline void to_json(nlohmann::json& j, const NerfDataset& dataset) {
 	j["n_images"] = dataset.n_images;
+        j["paths"] = dataset.paths;
 	for (size_t i = 0; i < dataset.n_images; ++i) {
 		j["metadata"].emplace_back();
 		j["xforms"].emplace_back();
@@ -175,6 +176,11 @@ inline void from_json(const nlohmann::json& j, NerfDataset& dataset) {
 			from_json(ji.at("rolling_shutter"), dataset.metadata[i].rolling_shutter);
 			from_json(ji.at("camera_distortion"), dataset.metadata[i].camera_distortion);
 		}
+		if (j.contains("paths")) {
+			dataset.paths.push_back(j["paths"].at(i));
+		} else {
+ 			dataset.paths.push_back(std::string(""));
+                }
 	}
 
 	dataset.render_aabb = j.at("render_aabb");

--- a/include/neural-graphics-primitives/nerf_loader.h
+++ b/include/neural-graphics-primitives/nerf_loader.h
@@ -73,6 +73,7 @@ struct NerfDataset {
 	void update_metadata(int first = 0, int last = -1);
 
 	std::vector<TrainingXForm> xforms;
+	std::vector<std::string> paths;
 	tcnn::GPUMemory<float> sharpness_data;
 	Eigen::Vector2i sharpness_resolution = {0, 0};
 	tcnn::GPUMemory<float> envmap_data;

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -311,6 +311,8 @@ public:
 	Eigen::Vector3f view_up() const { return m_camera.col(1); }
 	Eigen::Vector3f view_side() const { return m_camera.col(0); }
 	void set_view_dir(const Eigen::Vector3f& dir);
+	void first_training_view();
+	void last_training_view();
 	void previous_training_view();
 	void next_training_view();
 	void set_camera_to_training_view(int trainview);

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -311,6 +311,8 @@ public:
 	Eigen::Vector3f view_up() const { return m_camera.col(1); }
 	Eigen::Vector3f view_side() const { return m_camera.col(0); }
 	void set_view_dir(const Eigen::Vector3f& dir);
+	void previous_training_view();
+	void next_training_view();
 	void set_camera_to_training_view(int trainview);
 	void reset_camera();
 	bool keyboard_event();

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -186,6 +186,7 @@ NerfDataset create_empty_nerf_dataset(size_t n_images, int aabb_scale, bool is_h
 	result.offset = {0.5f, 0.5f, 0.5f};
 	result.aabb_scale = aabb_scale;
 	result.is_hdr = is_hdr;
+	result.paths = std::vector<std::string>(n_images, std::string());
 	for (size_t i = 0; i < n_images; ++i) {
 		result.xforms[i].start = Eigen::Matrix<float, 3, 4>::Identity();
 		result.xforms[i].end = Eigen::Matrix<float, 3, 4>::Identity();

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -377,6 +377,10 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 			}
 		}
 
+		for (int i = 0; i < (int)frames.size(); ++i) {
+			result.paths.push_back(frames[i]["file_path"]);
+		}
+
 		result.n_images += frames.size();
 	}
 

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -442,6 +442,10 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("screen_center", &Testbed::m_screen_center)
 		.def("set_nerf_camera_matrix", &Testbed::set_nerf_camera_matrix)
 		.def("set_camera_to_training_view", &Testbed::set_camera_to_training_view)
+		.def("first_training_view", &Testbed::first_training_view)
+		.def("last_training_view", &Testbed::last_training_view)
+		.def("previous_training_view", &Testbed::previous_training_view)
+		.def("next_training_view", &Testbed::next_training_view)
 		.def("compute_image_mse", &Testbed::compute_image_mse,
 			py::arg("quantize") = false
 		)
@@ -530,6 +534,7 @@ PYBIND11_MODULE(pyngp, m) {
 	nerfdataset
 		.def_readonly("metadata", &NerfDataset::metadata)
 		.def_readonly("transforms", &NerfDataset::xforms)
+		.def_readonly("paths", &NerfDataset::paths)
 		.def_readonly("render_aabb", &NerfDataset::render_aabb)
 		.def_readonly("render_aabb_to_local", &NerfDataset::render_aabb_to_local)
 		.def_readonly("up", &NerfDataset::up)

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1179,7 +1179,6 @@ void glfw_error_callback(int error, const char* description) {
 }
 
 bool Testbed::keyboard_event() {
-	ImGuiIO& io = ImGui::GetIO();
 	if (ImGui::GetIO().WantCaptureKeyboard) {
 		return false;
 	}
@@ -1266,9 +1265,9 @@ bool Testbed::keyboard_event() {
 		reset_accumulation();
 	}
 
-	if (io.KeyShift && ImGui::IsKeyPressed('[')) {
+	if (shift && ImGui::IsKeyPressed('[')) {
 		first_training_view();
-	} else if (io.KeyShift && ImGui::IsKeyPressed(']')) {
+	} else if (shift && ImGui::IsKeyPressed(']')) {
 		last_training_view();
 	} else if (ImGui::IsKeyPressed('[')) {
 		previous_training_view();

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -798,10 +798,7 @@ void Testbed::imgui() {
 					last_training_view();
 				}
 				ImGui::SameLine();
-				try
-				{
-					ImGui::Text("%s", m_nerf.training.dataset.paths.at(m_nerf.training.view).c_str());
-				} catch (std::out_of_range const&) {}
+				ImGui::Text("%s", m_nerf.training.dataset.paths.at(m_nerf.training.view).c_str());
 				if (ImGui::SliderInt("Training view", &m_nerf.training.view, 0, (int)m_nerf.training.dataset.n_images-1)) {
 					set_camera_to_training_view(m_nerf.training.view);
 					accum_reset = true;

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -238,6 +238,18 @@ void Testbed::set_view_dir(const Vector3f& dir) {
 	set_look_at(old_look_at);
 }
 
+void Testbed::first_training_view() {
+	m_nerf.training.view = 0;
+	set_camera_to_training_view(m_nerf.training.view);
+	reset_accumulation();
+}
+
+void Testbed::last_training_view() {
+	m_nerf.training.view = m_nerf.training.dataset.n_images-1;
+	set_camera_to_training_view(m_nerf.training.view);
+	reset_accumulation();
+}
+
 void Testbed::previous_training_view() {
 	if (m_nerf.training.view != 0) {
 		m_nerf.training.view -= 1;
@@ -770,6 +782,10 @@ void Testbed::imgui() {
 			}
 
 			if (m_testbed_mode == ETestbedMode::Nerf) {
+				if (ImGui::Button("First")) {
+					first_training_view();
+				}
+				ImGui::SameLine();
 				if (ImGui::Button("<")) {
 					previous_training_view();
 				}
@@ -778,13 +794,14 @@ void Testbed::imgui() {
 					next_training_view();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("Reset")) {
-					m_nerf.training.view = 0;
-					set_camera_to_training_view(m_nerf.training.view);
-					accum_reset = true;
+				if (ImGui::Button("Last")) {
+					last_training_view();
 				}
 				ImGui::SameLine();
-				ImGui::Text(m_nerf.training.dataset.paths[m_nerf.training.view].c_str());
+				try
+				{
+					ImGui::Text("%s", m_nerf.training.dataset.paths.at(m_nerf.training.view).c_str());
+				} catch (std::out_of_range const&) {}
 				if (ImGui::SliderInt("Training view", &m_nerf.training.view, 0, (int)m_nerf.training.dataset.n_images-1)) {
 					set_camera_to_training_view(m_nerf.training.view);
 					accum_reset = true;
@@ -1251,7 +1268,11 @@ bool Testbed::keyboard_event() {
 		reset_accumulation();
 	}
 
-	if (ImGui::IsKeyPressed('[')) {
+	if (ImGui::IsKeyPressed('{')) {
+		first_training_view();
+	} else if (ImGui::IsKeyPressed('}')) {
+		last_training_view();
+	} else if (ImGui::IsKeyPressed('[')) {
 		previous_training_view();
 	} else if (ImGui::IsKeyPressed(']')) {
 		next_training_view();

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -786,11 +786,11 @@ void Testbed::imgui() {
 					first_training_view();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("<")) {
+				if (ImGui::Button("Previous")) {
 					previous_training_view();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button(">")) {
+				if (ImGui::Button("Next")) {
 					next_training_view();
 				}
 				ImGui::SameLine();
@@ -1179,6 +1179,7 @@ void glfw_error_callback(int error, const char* description) {
 }
 
 bool Testbed::keyboard_event() {
+	ImGuiIO& io = ImGui::GetIO();
 	if (ImGui::GetIO().WantCaptureKeyboard) {
 		return false;
 	}
@@ -1265,9 +1266,9 @@ bool Testbed::keyboard_event() {
 		reset_accumulation();
 	}
 
-	if (ImGui::IsKeyPressed('{')) {
+	if (io.KeyShift && ImGui::IsKeyPressed('[')) {
 		first_training_view();
-	} else if (ImGui::IsKeyPressed('}')) {
+	} else if (io.KeyShift && ImGui::IsKeyPressed(']')) {
 		last_training_view();
 	} else if (ImGui::IsKeyPressed('[')) {
 		previous_training_view();

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -789,10 +789,6 @@ void Testbed::imgui() {
 					set_camera_to_training_view(m_nerf.training.view);
 					accum_reset = true;
 				}
-				if (ImGui::SliderInt("Training view", &m_nerf.training.view, 0, (int)m_nerf.training.dataset.n_images-1)) {
-					set_camera_to_training_view(m_nerf.training.view);
-					accum_reset = true;
-				}
 				ImGui::PlotLines("Training view error", m_nerf.training.error_map.pmf_img_cpu.data(), m_nerf.training.error_map.pmf_img_cpu.size(), 0, nullptr, 0.0f, FLT_MAX, ImVec2(0, 60.f));
 
 				if (m_nerf.training.optimize_exposure) {


### PR DESCRIPTION
Added buttons for previous, next and reset (go to first training view), and keys [ for previous and ] for next

We also show the name of the image for the training view (updated whenever the view is changed to a training view)

We found these buttons/keys quite useful for stepping through datasets to find bad cameras.