### PR TITLE
Fix several issues with snapshots

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -291,6 +291,7 @@ public:
 	void reset_network();
 	void create_empty_nerf_dataset(size_t n_images, int aabb_scale = 1, bool is_hdr = false);
 	void load_nerf();
+	void load_nerf_post();
 	void load_mesh();
 	void set_exposure(float exposure) { m_exposure = exposure; }
 	void set_max_level(float maxlevel);

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -334,8 +334,8 @@ PYBIND11_MODULE(pyngp, m) {
 			py::arg("second_window") = false
 		)
 		.def_readwrite("keyboard_event_callback", &Testbed::m_keyboard_event_callback)
-		.def("is_key_pressed", [](py::object& obj, char key) { return ImGui::IsKeyPressed(key); })
-		.def("is_key_down", [](py::object& obj, char key) { return ImGui::IsKeyDown(key); })
+		.def("is_key_pressed", [](py::object& obj, int key) { return ImGui::IsKeyPressed(key); })
+		.def("is_key_down", [](py::object& obj, int key) { return ImGui::IsKeyDown(key); })
 		.def("is_alt_down", [](py::object& obj) { return ImGui::GetIO().KeyMods & ImGuiKeyModFlags_Alt; })
 		.def("is_ctrl_down", [](py::object& obj) { return ImGui::GetIO().KeyMods & ImGuiKeyModFlags_Ctrl; })
 		.def("is_shift_down", [](py::object& obj) { return ImGui::GetIO().KeyMods & ImGuiKeyModFlags_Shift; })


### PR DESCRIPTION
- Snapshot w/ optimizer state no longer crashes
- Versioning of snapshots to prevent crashes upon loading older formats
- Smaller filesize due to saving density grids only up to `m_nerf.max_cascade`
- Even smaller filesize due to saving density grids at half precision