### PR TITLE
Visualizing depth results by inverse depth

### DIFF
--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -925,7 +925,9 @@ __global__ void composite_kernel_nerf(
 		} else if (render_mode == ERenderMode::EncodingVis) {
 			rgb = warped_pos.array();
 		} else if (render_mode == ERenderMode::Depth) {
-			rgb = Array3f::Constant(cam_fwd.dot(pos - origin) * depth_scale);
+			float depth_here = cam_fwd.dot(pos - origin) * depth_scale;
+			float depth_inv = (1/(depth_here+ 1e-9) -0.005)/9.995; // convert to inverse depth and limited to [0.1, 200]  
+			rgb = Array3f::Constant(depth_inv);
 		} else if (render_mode == ERenderMode::AO) {
 			rgb = Array3f::Constant(alpha);
 		}


### PR DESCRIPTION
Convert depth to inverse depth for a better visualization result under depth render mode in image GUI.
![color](https://user-images.githubusercontent.com/56543318/178141477-403b9372-ad18-4dca-885b-57298435c001.png)
![invdepth](https://user-images.githubusercontent.com/56543318/178141482-ded660c4-59d0-4f78-aa7c-258362e932e2.png)
