### PR TITLE
Use max number of parallel jobs when compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ cd instant-ngp
 Then, use CMake to build the project: (on Windows, this must be in a [developer command prompt](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_prompt))
 ```sh
 instant-ngp$ cmake . -B build
-instant-ngp$ cmake --build build --config RelWithDebInfo -j 16
+instant-ngp$ cmake --build build --config RelWithDebInfo -j
 ```
 
 If the build fails, please consult [this list of possible fixes](https://github.com/NVlabs/instant-ngp#troubleshooting-compile-errors) before opening an issue.


### PR DESCRIPTION
https://linux.die.net/man/1/make

"If the -j option is given without an argument, make will not limit the number of jobs that can run simultaneously."