### PR TITLE
switching back to single view with dimension -1

### DIFF
--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -768,9 +768,7 @@ void Testbed::imgui() {
 				set_visualized_layer(m_visualized_layer);
 			}
 			if (ImGui::Checkbox("Single view", &m_single_view)) {
-				if (!m_single_view) {
-					set_visualized_dim(-1);
-				}
+				set_visualized_dim(-1);
 				accum_reset = true;
 			}
 


### PR DESCRIPTION
Related to #106 , switching back to single view is not working as intended. 
The dimension of single view changed to network width after swtiching back from multi view.

So I've changed the condition of single view dimension as intended.