### PR TITLE
Add ability to change groundtruth alpha

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -432,6 +432,7 @@ public:
 	bool m_include_optimizer_state_in_snapshot = false;
 	bool m_render_ground_truth = false;
 	EGroundTruthRenderMode m_ground_truth_render_mode = EGroundTruthRenderMode::Shade;
+	float m_ground_truth_alpha = 1.0f;
 
 	bool m_train = false;
 	bool m_training_data_available = false;


### PR DESCRIPTION
Let the user adjust the alpha to see both groundtruth and render at the same time

![InstantNGPAlphaGT](https://user-images.githubusercontent.com/29726242/187336501-3308bf33-9fec-4cc7-84ee-f73755c11f6f.gif)