### PR TITLE
fixed a bug where nerf loader incorrectly read distortion params  where there are multiple jsons file

### DIFF
--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -683,7 +683,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 			result.metadata[i_img].principal_point = principal_point;
 			result.metadata[i_img].camera_distortion = camera_distortion;
 			// see if there is a per-frame override
-			read_camera_distortion(frame, result.metadata[i_img].camera_distortion, result.metadata[i_img].principal_point, result.metadata[i_img].rolling_shutter);
+			read_camera_distortion(json, result.metadata[i_img].camera_distortion, result.metadata[i_img].principal_point, result.metadata[i_img].rolling_shutter);
 
 			result.xforms[i_img].start = result.nerf_matrix_to_ngp(result.xforms[i_img].start);
 			result.xforms[i_img].end = result.nerf_matrix_to_ngp(result.xforms[i_img].end);


### PR DESCRIPTION
when there are multiple json files in the scenes with different camera distortion the loader incorrectly reads them. 
there bug occurs because the frame dictionary was given to the function read_camera_distotion instead of the whole json dictionary