### PR TITLE
Fix memory alignment issue

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -60,6 +60,7 @@ class GLTexture;
 
 class Testbed {
 public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 	Testbed(ETestbedMode mode);
 	~Testbed();
 	Testbed(ETestbedMode mode, const std::string& data_path) : Testbed(mode) { load_training_data(data_path); }


### PR DESCRIPTION
This is a bit of a weird bug and only happens when you are running instant ngp through python. To replicate the issue:
Go to testbed.h and add another matrix member.
```cpp
class Testbed{
...
Eigen::Matrix4f test;
}
```

Then run scripts/run.py several times

The script will fail randomly with a seg fault. The EIGEN_MAKE_ALIGNED_OPERATOR_NEW fixes the issue. Presumably python is allocating Testbed at random memory addresses. Sometimes they align and sometimes they don't. 
