### PR TITLE
normalize dir before calculating origin based on near distance

### DIFF
--- a/include/neural-graphics-primitives/common_device.cuh
+++ b/include/neural-graphics-primitives/common_device.cuh
@@ -311,7 +311,7 @@ inline NGP_HOST_DEVICE Ray pixel_to_ray(
 		dir = (lookat - origin) / focus_z;
 	}
 	
-	origin += dir * near_distance;
+	origin += dir.normalized() * near_distance;
 
 	return {origin, dir};
 }


### PR DESCRIPTION
i'm back 😅 

I think I made a mistake, `pixel_to_ray` doesn't normalize the ray direction, so I believe my calculation was inaccurate.  Should be good now 👍 