### PR TITLE
Better colmap2nerf script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 __pycache__
 .DS_Store
 imgui.ini
+data/nerf/custom/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__
 .DS_Store
 imgui.ini
 data/nerf/custom/*
+*colmap_sparse
+*colmap_text
+*colmap.db

--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -36,7 +36,7 @@ def parse_args():
 	parser.add_argument("--aabb_scale", default=16, choices=["1","2","4","8","16"], help="large scene scale factor. 1=scene fits in unit cube; power of 2 up to 16")
 	parser.add_argument("--skip_early", default=0, help="skip this many images from the start")
 	parser.add_argument("--keep_colmap_coords", action="store_true", help="keep transforms.json in COLMAP's original frame of reference (this will avoid reorienting and repositioning the scene for preview and rendering)")
-	parser.add_argument("--out", default="transforms.json", help="output path")
+	parser.add_argument("--out", default="", help="output path")
 	parser.add_argument("--vocab_path", default="", help="vocabulary tree path")
 	parser.add_argument("--num_threads", default=-1, help="number of threads to use for colmap")
 	args = parser.parse_args()
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 	SKIP_EARLY = int(args.skip_early)
 	IMAGE_FOLDER = args.images
 	TEXT_FOLDER = args.text
-	OUT_PATH = args.out
+	OUT_PATH = args.out + "transforms.json"
 	print(f"outputting to {OUT_PATH}...")
 	with open(os.path.join(TEXT_FOLDER,"cameras.txt"), "r") as f:
 		angle_x = math.pi / 2

--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -38,6 +38,7 @@ def parse_args():
 	parser.add_argument("--keep_colmap_coords", action="store_true", help="keep transforms.json in COLMAP's original frame of reference (this will avoid reorienting and repositioning the scene for preview and rendering)")
 	parser.add_argument("--out", default="transforms.json", help="output path")
 	parser.add_argument("--vocab_path", default="", help="vocabulary tree path")
+	parser.add_argument("--num_threads", default=-1, help="number of threads to use for colmap")
 	args = parser.parse_args()
 	return args
 
@@ -85,7 +86,7 @@ def run_colmap(args):
 		sys.exit(1)
 	if os.path.exists(db):
 		os.remove(db)
-	do_system(f"colmap feature_extractor --ImageReader.camera_model {args.colmap_camera_model} --ImageReader.camera_params \"{args.colmap_camera_params}\" --SiftExtraction.estimate_affine_shape=true --SiftExtraction.domain_size_pooling=true --ImageReader.single_camera 1 --database_path {db} --image_path {images}")
+	do_system(f"colmap feature_extractor --ImageReader.camera_model {args.colmap_camera_model} --ImageReader.camera_params \"{args.colmap_camera_params}\" --SiftExtraction.estimate_affine_shape=true --SiftExtraction.domain_size_pooling=true, --SiftExtraction.num_threads {args.num_threads} --ImageReader.single_camera 1 --database_path {db} --image_path {images}")
 	match_cmd = f"colmap {args.colmap_matcher}_matcher --SiftMatching.guided_matching=true --database_path {db}"
 	if args.vocab_path:
 		match_cmd += f" --VocabTreeMatching.vocab_tree_path {args.vocab_path}"
@@ -327,5 +328,6 @@ if __name__ == "__main__":
 		f["transform_matrix"] = f["transform_matrix"].tolist()
 	print(nframes,"frames")
 	print(f"writing {OUT_PATH}")
+
 	with open(OUT_PATH, "w") as outfile:
 		json.dump(out, outfile, indent=2)


### PR DESCRIPTION
# colmap2nerf overhaul
Today I was about to train my own dataset. For this you need to pass it through the colmap2nerf script but I encountered some problems with generating these.

## File path handling
From what I understand you are able to run the script either:
-  from the image parent directory.
- or define the the images/out directory using the --images and --out flags

The first one works like expected, but the problem here is that you need to run the script from the actual image parent directory, linking to the script by defining the absolute path. This is far from ideal. 

The second one does not function like expected, because it fills the transforms.json file with incorrect file paths. These are also partly in the UNIX format and this messes things up in Windows. Another problem with this, is that you always need to end the --out flag with "transforms.json". If not, Python goes in error because it is trying to access a directory instead of a file.

Another problem I encountered was that colmap defaulted to use all threads, resulting in the system freezing due to using way to much resources. This was easily fixed by adding an argument defining the amount of threads.

## What was fixed
- Running the script is now possible from the instant-ngp root directory + allocation of threads resulting in stable system.
Example usage:
```
python scripts\colmap2nerf.py --colmap_matcher exhaustive --run_colmap --aabb_scale
 8 --images .\data\nerf\custom\guitar\images\ --num_threads 6
```
- File paths are now formatted correctly using os.path.normpath()
- transform.json get's appended to the path given in --out
- Added a "custom folder" that doesn't push to version control

When using the script, colmap generates some files inside the root directory. I don't think these are ment for version control so I added a patern to ignore these.

Fantastic project by the way! ;)
