### PR TITLE
Add support for the OpenCV fisheye lens models

### DIFF
--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -192,7 +192,9 @@ enum class ELensMode : int {
 	OpenCV,
 	FTheta,
 	LatLong,
+	OpenCVFisheye,
 };
+static constexpr const char* LensModeStr = "Perspective\0OpenCV\0F-Theta\0LatLong\0OpenCV Fisheye\0\0";
 
 struct Lens {
 	ELensMode mode = ELensMode::Perspective;

--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -82,10 +82,17 @@ inline void from_json(const nlohmann::json& j, BoundingBox& box) {
 
 inline void to_json(nlohmann::json& j, const Lens& lens) {
 	if (lens.mode == ELensMode::OpenCV) {
+		j["is_fisheye"] = false;
 		j["k1"] = lens.params[0];
 		j["k2"] = lens.params[1];
 		j["p1"] = lens.params[2];
 		j["p2"] = lens.params[3];
+	} else if (lens.mode == ELensMode::OpenCVFisheye) {
+		j["is_fisheye"] = true;
+		j["k1"] = lens.params[0];
+		j["k2"] = lens.params[1];
+		j["k3"] = lens.params[2];
+		j["k4"] = lens.params[3];
 	} else if (lens.mode == ELensMode::FTheta) {
 		j["ftheta_p0"] = lens.params[0];
 		j["ftheta_p1"] = lens.params[1];
@@ -99,11 +106,19 @@ inline void to_json(nlohmann::json& j, const Lens& lens) {
 
 inline void from_json(const nlohmann::json& j, Lens& lens) {
 	if (j.contains("k1")) {
-		lens.mode = ELensMode::OpenCV;
-		lens.params[0] = j.at("k1");
-		lens.params[1] = j.at("k2");
-		lens.params[2] = j.at("p1");
-		lens.params[3] = j.at("p2");
+		if (j.value("is_fisheye", false)) {
+			lens.mode = ELensMode::OpenCVFisheye;
+			lens.params[0] = j.at("k1");
+			lens.params[1] = j.at("k2");
+			lens.params[2] = j.at("k3");
+			lens.params[3] = j.at("k4");
+		} else {
+			lens.mode = ELensMode::OpenCV;
+			lens.params[0] = j.at("k1");
+			lens.params[1] = j.at("k2");
+			lens.params[2] = j.at("p1");
+			lens.params[3] = j.at("p2");
+		}
 	} else if (j.contains("ftheta_p0")) {
 		lens.mode = ELensMode::FTheta;
 		lens.params[0] = j.at("ftheta_p0");

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -620,7 +620,7 @@ public:
 
 			tcnn::GPUMemory<float> sharpness_grid;
 
-			void set_camera_intrinsics(int frame_idx, float fx, float fy = 0.0f, float cx = -0.5f, float cy = -0.5f, float k1 = 0.0f, float k2 = 0.0f, float p1 = 0.0f, float p2 = 0.0f);
+			void set_camera_intrinsics(int frame_idx, float fx, float fy = 0.0f, float cx = -0.5f, float cy = -0.5f, float k1 = 0.0f, float k2 = 0.0f, float p1 = 0.0f, float p2 = 0.0f, float k3 = 0.0f, float k4 = 0.0f, bool is_fisheye = false);
 			void set_camera_extrinsics_rolling_shutter(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world_start, Eigen::Matrix<float, 3, 4> camera_to_world_end, const Eigen::Vector4f& rolling_shutter, bool convert_to_ngp = true);
 			void set_camera_extrinsics(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world, bool convert_to_ngp = true);
 			Eigen::Matrix<float, 3, 4> get_camera_extrinsics(int frame_idx);

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -314,6 +314,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.value("OpenCV", ELensMode::OpenCV)
 		.value("FTheta", ELensMode::FTheta)
 		.value("LatLong", ELensMode::LatLong)
+		.value("OpenCVFisheye", ELensMode::OpenCVFisheye)
 		.export_values();
 
 	py::class_<BoundingBox>(m, "BoundingBox")
@@ -621,6 +622,8 @@ PYBIND11_MODULE(pyngp, m) {
 			py::arg("cx")=-0.5f, py::arg("cy")=-0.5f,
 			py::arg("k1")=0.f, py::arg("k2")=0.f,
 			py::arg("p1")=0.f, py::arg("p2")=0.f,
+			py::arg("k3")=0.f, py::arg("k4")=0.f,
+			py::arg("is_fisheye")=false,
 			"Set up the camera intrinsics for the given training image index."
 		)
 		.def("set_camera_extrinsics", &Testbed::Nerf::Training::set_camera_extrinsics,

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -864,12 +864,17 @@ void Testbed::imgui() {
 			accum_reset |= ImGui::Checkbox("Apply lens distortion", &m_nerf.render_with_lens_distortion);
 
 			if (m_nerf.render_with_lens_distortion) {
-				accum_reset |= ImGui::Combo("Lens mode", (int*)&m_nerf.render_lens.mode, "Perspective\0OpenCV\0F-Theta\0LatLong\0");
+				accum_reset |= ImGui::Combo("Lens mode", (int*)&m_nerf.render_lens.mode, LensModeStr);
 				if (m_nerf.render_lens.mode == ELensMode::OpenCV) {
 					accum_reset |= ImGui::InputFloat("k1", &m_nerf.render_lens.params[0], 0.f, 0.f, "%.5f");
 					accum_reset |= ImGui::InputFloat("k2", &m_nerf.render_lens.params[1], 0.f, 0.f, "%.5f");
 					accum_reset |= ImGui::InputFloat("p1", &m_nerf.render_lens.params[2], 0.f, 0.f, "%.5f");
 					accum_reset |= ImGui::InputFloat("p2", &m_nerf.render_lens.params[3], 0.f, 0.f, "%.5f");
+				} else if (m_nerf.render_lens.mode == ELensMode::OpenCVFisheye) {
+					accum_reset |= ImGui::InputFloat("k1", &m_nerf.render_lens.params[0], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("k2", &m_nerf.render_lens.params[1], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("k3", &m_nerf.render_lens.params[2], 0.f, 0.f, "%.5f");
+					accum_reset |= ImGui::InputFloat("k4", &m_nerf.render_lens.params[3], 0.f, 0.f, "%.5f");
 				} else if (m_nerf.render_lens.mode == ELensMode::FTheta) {
 					accum_reset |= ImGui::InputFloat("width", &m_nerf.render_lens.params[5], 0.f, 0.f, "%.0f");
 					accum_reset |= ImGui::InputFloat("height", &m_nerf.render_lens.params[6], 0.f, 0.f, "%.0f");


### PR DESCRIPTION
Specifically, `colmap2nerf.py` can now be run with the following additional lens models
- SIMPLE_RADIAL_FISHEYE
- RADIAL_FISHEYE
- OPENCV_FISHEYE

and __instant-ngp__ will correctly compensate / apply / render the corresponding lens distortion.

Related to https://github.com/NVlabs/instant-ngp/discussions/547