### PR TITLE
Support unicode filenames and paths on Windows

### DIFF
--- a/dependencies/filesystem/filesystem/directory.h
+++ b/dependencies/filesystem/filesystem/directory.h
@@ -39,8 +39,8 @@ public:
         iterator(const directory& dir) {
             m_dir = dir;
 #if defined(_WIN32)
-            std::string search_path(dir.make_absolute().str() + "/*.*");
-            m_handle = _findfirst(search_path.c_str(), &m_data);
+            std::wstring search_path(dir.make_absolute().wstr() + L"/*.*");
+            m_handle = _wfindfirst(search_path.c_str(), &m_data);
             if (is_valid_handler())
             {
                 m_result = m_dir / m_data.name;
@@ -72,7 +72,7 @@ public:
             if (is_valid_handler())
             {
 #if defined(_WIN32)
-                if (_findnext(m_handle, &m_data))
+                if (_wfindnext(m_handle, &m_data))
                 {
                     if (ENOENT == errno) /* reaching the end */
                     {
@@ -133,7 +133,7 @@ public:
         path m_result;
 #if defined(_WIN32)
         intptr_t m_handle;
-        _finddata_t m_data;
+        _wfinddata_t m_data;
 #else
         DIR* m_handle;
         struct dirent* m_data;

--- a/dependencies/filesystem/filesystem/path.h
+++ b/dependencies/filesystem/filesystem/path.h
@@ -296,6 +296,8 @@ public:
 			m_path = tokenize(str, "/");
 			m_absolute = !str.empty() && str[0] == '/';
 		}
+
+		m_path.erase(std::remove(std::begin(m_path), std::end(m_path), ""), std::end(m_path));
 	}
 
 	path &operator=(const path &path) {

--- a/include/neural-graphics-primitives/camera_path.h
+++ b/include/neural-graphics-primitives/camera_path.h
@@ -132,8 +132,8 @@ struct CameraPath {
 #ifdef NGP_GUI
 	ImGuizmo::MODE m_gizmo_mode = ImGuizmo::LOCAL;
 	ImGuizmo::OPERATION m_gizmo_op = ImGuizmo::TRANSLATE;
-	int imgui(char path_filename_buf[128], float frame_milliseconds, Eigen::Matrix<float, 3, 4>& camera, float slice_plane_z, float scale, float fov, float aperture_size, float bounding_radius, const Eigen::Matrix<float, 3, 4>& first_xform, int glow_mode, float glow_y_cutoff);
 	bool imgui_viz(ImDrawList* list, Eigen::Matrix<float, 4, 4>& view2proj, Eigen::Matrix<float, 4, 4>& world2proj, Eigen::Matrix<float, 4, 4>& world2view, Eigen::Vector2f focal, float aspect);
+	int imgui(char path_filename_buf[1024], float frame_milliseconds, Eigen::Matrix<float, 3, 4>& camera, float slice_plane_z, float scale, float fov, float aperture_size, float bounding_radius, const Eigen::Matrix<float, 3, 4>& first_xform, int glow_mode, float glow_y_cutoff);
 #endif
 };
 

--- a/include/neural-graphics-primitives/camera_path.h
+++ b/include/neural-graphics-primitives/camera_path.h
@@ -126,8 +126,8 @@ struct CameraPath {
 		return spline(t-floorf(t), get_keyframe(t1-1), get_keyframe(t1), get_keyframe(t1+1), get_keyframe(t1+2));
 	}
 
-	void save(const std::string& filepath_string);
-	void load(const std::string& filepath_string, const Eigen::Matrix<float, 3, 4> &first_xform);
+	void save(const fs::path& path);
+	void load(const fs::path& path, const Eigen::Matrix<float, 3, 4> &first_xform);
 
 #ifdef NGP_GUI
 	ImGuizmo::MODE m_gizmo_mode = ImGuizmo::LOCAL;

--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -63,10 +63,20 @@
 
 NGP_NAMESPACE_BEGIN
 
+namespace fs = filesystem;
+
 bool is_wsl();
 
-filesystem::path get_executable_dir();
-filesystem::path get_root_dir();
+fs::path get_executable_dir();
+fs::path get_root_dir();
+
+#ifdef _WIN32
+std::string utf16_to_utf8(const std::wstring& utf16);
+std::wstring utf8_to_utf16(const std::string& utf16);
+std::wstring native_string(const fs::path& path);
+#else
+std::string native_string(const fs::path& path);
+#endif
 
 bool ends_with(const std::string& str, const std::string& ending);
 bool ends_with_case_insensitive(const std::string& str, const std::string& ending);
@@ -332,5 +342,13 @@ private:
 	int64_t m_last_progress = 0;
 	std::chrono::time_point<std::chrono::steady_clock> m_creation_time;
 };
+
+uint8_t* load_stbi(const fs::path& path, int* width, int* height, int* comp, int req_comp);
+float* load_stbi_float(const fs::path& path, int* width, int* height, int* comp, int req_comp);
+uint16_t* load_stbi_16(const fs::path& path, int* width, int* height, int* comp, int req_comp);
+bool is_hdr_stbi(const fs::path& path);
+int write_stbi(const fs::path& path, int width, int height, int comp, const uint8_t* pixels, int quality = 100);
+
+FILE* native_fopen(const fs::path& path, const char* mode);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/common_device.cuh
+++ b/include/neural-graphics-primitives/common_device.cuh
@@ -756,7 +756,7 @@ inline NGP_HOST_DEVICE float read_depth(Eigen::Vector2f pos, const Eigen::Vector
 
 Eigen::Matrix<float, 3, 4> log_space_lerp(const Eigen::Matrix<float, 3, 4>& begin, const Eigen::Matrix<float, 3, 4>& end, float t);
 
-tcnn::GPUMemory<float> load_exr(const std::string& filename, int& width, int& height);
-tcnn::GPUMemory<float> load_stbi(const std::string& filename, int& width, int& height);
+tcnn::GPUMemory<float> load_exr_gpu(const fs::path& path, int* width, int* height);
+tcnn::GPUMemory<float> load_stbi_gpu(const fs::path& path, int* width, int* height);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/marching_cubes.h
+++ b/include/neural-graphics-primitives/marching_cubes.h
@@ -46,7 +46,7 @@ void save_mesh(
 	tcnn::GPUMemory<Eigen::Vector3f>& normals,
 	tcnn::GPUMemory<Eigen::Vector3f>& colors,
 	tcnn::GPUMemory<uint32_t>& indices,
-	const char* outputname,
+	const fs::path& path,
 	bool unwrap_it,
 	float nerf_scale,
 	Eigen::Vector3f nerf_offset
@@ -70,10 +70,10 @@ uint32_t compile_shader(bool pixel, const char* code);
 bool check_shader(uint32_t handle, const char* desc, bool program);
 #endif
 
-void save_density_grid_to_png(const tcnn::GPUMemory<float>& density, const char* filename, Eigen::Vector3i res3d, float thresh, bool swap_y_z = true, float density_range = 4.f);
+void save_density_grid_to_png(const tcnn::GPUMemory<float>& density, const fs::path& path, Eigen::Vector3i res3d, float thresh, bool swap_y_z = true, float density_range = 4.f);
 
-void save_rgba_grid_to_png_sequence(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const char *path, Eigen::Vector3i res3d, bool swap_y_z = true);
+void save_rgba_grid_to_png_sequence(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const fs::path& path, Eigen::Vector3i res3d, bool swap_y_z = true);
 
-void save_rgba_grid_to_raw_file(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const char* path, Eigen::Vector3i res3d, bool swap_y_z, int cascade);
+void save_rgba_grid_to_raw_file(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const fs::path& path, Eigen::Vector3i res3d, bool swap_y_z, int cascade);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/nerf_loader.h
+++ b/include/neural-graphics-primitives/nerf_loader.h
@@ -180,7 +180,7 @@ struct NerfDataset {
 	}
 };
 
-NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float sharpen_amount = 0.f);
+NerfDataset load_nerf(const std::vector<fs::path>& jsonpaths, float sharpen_amount = 0.f);
 NerfDataset create_empty_nerf_dataset(size_t n_images, int aabb_scale = 1, bool is_hdr = false);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/render_buffer.h
+++ b/include/neural-graphics-primitives/render_buffer.h
@@ -105,7 +105,7 @@ public:
 
 	bool is_8bit() { return m_is_8bit; }
 
-	void load(const char* fname);
+	void load(const fs::path& path);
 
 	void load(const float* data, Eigen::Vector2i new_size, int n_channels);
 

--- a/include/neural-graphics-primitives/tinyexr_wrapper.h
+++ b/include/neural-graphics-primitives/tinyexr_wrapper.h
@@ -20,8 +20,8 @@
 
 NGP_NAMESPACE_BEGIN
 
-void save_exr(const float* data, int width, int height, int nChannels, int channelStride, const char* outfilename);
-void load_exr(float** data, int* width, int* height, const char* filename);
-__half* load_exr_to_gpu(int* width, int* height, const char* filename, bool fix_premult);
+void save_exr(const float* data, int width, int height, int nChannels, int channelStride, const fs::path& path);
+void load_exr(float** data, int* width, int* height, const fs::path& path);
+__half* load_exr_to_gpu(int* width, int* height, const fs::path& path, bool fix_premult);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/tinyobj_loader_wrapper.h
+++ b/include/neural-graphics-primitives/tinyobj_loader_wrapper.h
@@ -23,6 +23,6 @@
 
 NGP_NAMESPACE_BEGIN
 
-std::vector<Eigen::Vector3f> load_obj(const std::string& filename);
+std::vector<Eigen::Vector3f> load_obj(const fs::path& path);
 
 NGP_NAMESPACE_END

--- a/src/camera_path.cu
+++ b/src/camera_path.cu
@@ -107,20 +107,20 @@ void from_json(bool is_first, const json& j, CameraKeyframe& p, const CameraKeyf
 }
 
 
-void CameraPath::save(const std::string& filepath_string) {
+void CameraPath::save(const fs::path& path) {
 	json j = {
 		{"loop", loop},
 		{"time", play_time},
 		{"path", keyframes},
 	};
-	std::ofstream f(filepath_string);
+	std::ofstream f(native_string(path));
 	f << j;
 }
 
-void CameraPath::load(const std::string& filepath_string, const Eigen::Matrix<float, 3, 4>& first_xform) {
-	std::ifstream f(filepath_string);
+void CameraPath::load(const fs::path& path, const Eigen::Matrix<float, 3, 4>& first_xform) {
+	std::ifstream f{native_string(path)};
 	if (!f) {
-		throw std::runtime_error{fmt::format("Camera path {} does not exist.", filepath_string)};
+		throw std::runtime_error{fmt::format("Camera path {} does not exist.", path.str())};
 	}
 
 	json j;

--- a/src/camera_path.cu
+++ b/src/camera_path.cu
@@ -147,7 +147,7 @@ int CameraPath::imgui(char path_filename_buf[1024], float frame_milliseconds, Ma
 	int n = std::max(0, int(keyframes.size()) - 1);
 	int read = 0; // 1=smooth, 2=hard
 
-	ImGui::InputText("##PathFile", path_filename_buf, sizeof(path_filename_buf));
+	ImGui::InputText("##PathFile", path_filename_buf, 1024);
 	ImGui::SameLine();
 	static std::string camera_path_load_error_string = "";
 

--- a/src/common.cu
+++ b/src/common.cu
@@ -18,13 +18,39 @@
 
 #include <filesystem/path.h>
 
-#ifndef _WIN32
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+
+#ifdef __NVCC__
+#  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#    pragma nv_diag_suppress 550
+#  else
+#    pragma diag_suppress 550
+#  endif
+#endif
+#include <stb_image/stb_image.h>
+#include <stb_image/stb_image_write.h>
+#ifdef __NVCC__
+#  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#    pragma nv_diag_default 550
+#  else
+#    pragma diag_default 550
+#  endif
+#endif
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
 #  include <unistd.h>
 #  include <linux/limits.h>
 #endif
 
+#undef min
+#undef max
+#undef near
+#undef far
+
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -37,34 +63,61 @@ bool is_wsl() {
 		return false;
 	}
 
-	std::ifstream f{path.str()};
+	std::ifstream f{native_string(path)};
 	std::string content((std::istreambuf_iterator<char>(f)), (std::istreambuf_iterator<char>()));
 	return content.find("microsoft") != std::string::npos;
 #endif
 }
 
+#ifdef _WIN32
+std::string utf16_to_utf8(const std::wstring& utf16) {
+	std::string utf8;
+	if (!utf16.empty()) {
+		int size = WideCharToMultiByte(CP_UTF8, 0, &utf16[0], (int)utf16.size(), NULL, 0, NULL, NULL);
+		utf8.resize(size, 0);
+		WideCharToMultiByte(CP_UTF8, 0, &utf16[0], (int)utf16.size(), &utf8[0], size, NULL, NULL);
+	}
+	return utf8;
+}
+
+std::wstring utf8_to_utf16(const std::string& utf8) {
+	std::wstring utf16;
+	if (!utf8.empty()) {
+		int size = MultiByteToWideChar(CP_UTF8, 0, &utf8[0], (int)utf8.size(), NULL, 0);
+		utf16.resize(size, 0);
+		MultiByteToWideChar(CP_UTF8, 0, &utf8[0], (int)utf8.size(), &utf16[0], size);
+	}
+	return utf16;
+}
+
+std::wstring native_string(const fs::path& path) { return path.wstr(); }
+#else
+std::string native_string(const fs::path& path) { return path.str(); }
+#endif
+
 fs::path get_executable_dir() {
 #ifdef _WIN32
-	WCHAR path[MAX_PATH];
-	if (GetModuleFileNameW(NULL, path, MAX_PATH) == 0) {
+	WCHAR path[1024];
+	if (GetModuleFileNameW(NULL, path, 1024) == 0) {
 		return ".";
 	}
+	return fs::path{std::wstring{path}}.parent_path();
 #else
 	char path[PATH_MAX];
 	ssize_t count = readlink("/proc/self/exe", path, PATH_MAX);
 	if (count == -1) {
 		return ".";
 	}
+	return fs::path{std::string{path}}.parent_path();
 #endif
-	return fs::path{path}.parent_path();
 }
 
-filesystem::path get_root_dir() {
+fs::path get_root_dir() {
 	auto executable_dir = get_executable_dir();
-	fs::path exists_in_root_dir = "./scripts";
+	fs::path exists_in_root_dir = "scripts";
 	for (const auto& candidate : {
-		exists_in_root_dir,
-		fs::path{"../"}/exists_in_root_dir,
+		fs::path{"."}/exists_in_root_dir,
+		fs::path{".."}/exists_in_root_dir,
 		executable_dir/exists_in_root_dir,
 		executable_dir/".."/exists_in_root_dir,
 	}) {
@@ -128,6 +181,71 @@ std::string to_string(ETestbedMode mode) {
 		case ETestbedMode::None: return "none";
 		default: throw std::runtime_error{fmt::format("Can not convert mode {} to string.", (int)mode)};
 	}
+}
+
+static const stbi_io_callbacks istream_stbi_callbacks = {
+	// Read
+	[](void* context, char* data, int size) {
+		auto stream = reinterpret_cast<std::istream*>(context);
+		stream->read(data, size);
+		return (int)stream->gcount();
+	},
+	// Seek
+	[](void* context, int size) {
+		reinterpret_cast<std::istream*>(context)->seekg(size, std::ios_base::cur);
+	},
+	// EOF
+	[](void* context) {
+		return (int)!!(*reinterpret_cast<std::istream*>(context));
+	},
+};
+
+void istream_stbi_write_func(void* context, void* data, int size) {
+	reinterpret_cast<std::ostream*>(context)->write(reinterpret_cast<char*>(data), size);
+}
+
+uint8_t* load_stbi(const fs::path& path, int* width, int* height, int* comp, int req_comp) {
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
+	return stbi_load_from_callbacks(&istream_stbi_callbacks, &f, width, height, comp, req_comp);
+}
+
+float* load_stbi_float(const fs::path& path, int* width, int* height, int* comp, int req_comp) {
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
+	return stbi_loadf_from_callbacks(&istream_stbi_callbacks, &f, width, height, comp, req_comp);
+}
+
+uint16_t* load_stbi_16(const fs::path& path, int* width, int* height, int* comp, int req_comp) {
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
+	return stbi_load_16_from_callbacks(&istream_stbi_callbacks, &f, width, height, comp, req_comp);
+}
+
+bool is_hdr_stbi(const fs::path& path) {
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
+	return stbi_is_hdr_from_callbacks(&istream_stbi_callbacks, &f);
+}
+
+int write_stbi(const fs::path& path, int width, int height, int comp, const uint8_t* pixels, int quality) {
+	std::ofstream f{native_string(path), std::ios::out | std::ios::binary};
+
+	if (equals_case_insensitive(path.extension(), "jpg") || equals_case_insensitive(path.extension(), "jpeg")) {
+		return stbi_write_jpg_to_func(istream_stbi_write_func, &f, width, height, comp, pixels, quality);
+	} else if (equals_case_insensitive(path.extension(), "png")) {
+		return stbi_write_png_to_func(istream_stbi_write_func, &f, width, height, comp, pixels, width * comp);
+	} else if (equals_case_insensitive(path.extension(), "tga")) {
+		return stbi_write_tga_to_func(istream_stbi_write_func, &f, width, height, comp, pixels);
+	} else if (equals_case_insensitive(path.extension(), "bmp")) {
+		return stbi_write_bmp_to_func(istream_stbi_write_func, &f, width, height, comp, pixels);
+	} else {
+		throw std::runtime_error{fmt::format("write_stbi: unknown image extension '{}'", path.extension())};
+	}
+}
+
+FILE* native_fopen(const fs::path& path, const char* mode) {
+#ifdef _WIN32
+	return _wfopen(path.wstr().c_str(), utf8_to_utf16(mode).c_str());
+#else
+	return fopen(path.str().c_str(), mode);
+#endif
 }
 
 NGP_NAMESPACE_END

--- a/src/common_device.cu
+++ b/src/common_device.cu
@@ -36,25 +36,25 @@ Matrix<float, 3, 4> log_space_lerp(const Matrix<float, 3, 4>& begin, const Matri
 	return ((log_space_a_to_b * t).exp() * A).block<3,4>(0,0);
 }
 
-GPUMemory<float> load_exr(const std::string& filename, int& width, int& height) {
+GPUMemory<float> load_exr_gpu(const fs::path& path, int* width, int* height) {
 	float* out; // width * height * RGBA
-	load_exr(&out, &width, &height, filename.c_str());
+	load_exr(&out, width, height, path.str().c_str());
 	ScopeGuard mem_guard{[&]() { free(out); }};
 
-	GPUMemory<float> result(width * height * 4);
+	GPUMemory<float> result((*width) * (*height) * 4);
 	result.copy_from_host(out);
 	return result;
 }
 
-GPUMemory<float> load_stbi(const std::string& filename, int& width, int& height) {
-	bool is_hdr = stbi_is_hdr(filename.c_str());
+GPUMemory<float> load_stbi_gpu(const fs::path& path, int* width, int* height) {
+	bool is_hdr = is_hdr_stbi(path);
 
 	void* data; // width * height * RGBA
 	int comp;
 	if (is_hdr) {
-		data = stbi_loadf(filename.c_str(), &width, &height, &comp, 4);
+		data = load_stbi_float(path, width, height, &comp, 4);
 	} else {
-		data = stbi_load(filename.c_str(), &width, &height, &comp, 4);
+		data = load_stbi(path, width, height, &comp, 4);
 	}
 
 	if (!data) {
@@ -63,17 +63,17 @@ GPUMemory<float> load_stbi(const std::string& filename, int& width, int& height)
 
 	ScopeGuard mem_guard{[&]() { stbi_image_free(data); }};
 
-	if (width == 0 || height == 0) {
+	if (*width == 0 || *height == 0) {
 		throw std::runtime_error{"Image has zero pixels."};
 	}
 
-	GPUMemory<float> result(width * height * 4);
+	GPUMemory<float> result((*width) * (*height) * 4);
 	if (is_hdr) {
 		result.copy_from_host((float*)data);
 	} else {
-		GPUMemory<uint8_t> bytes(width * height * 4);
+		GPUMemory<uint8_t> bytes((*width) * (*height) * 4);
 		bytes.copy_from_host((uint8_t*)data);
-		linear_kernel(from_rgba32<float>, 0, nullptr, width * height, bytes.data(), result.data(), false, false, 0);
+		linear_kernel(from_rgba32<float>, 0, nullptr, (*width) * (*height), bytes.data(), result.data(), false, false, 0);
 	}
 
 	return result;

--- a/src/dlss.cu
+++ b/src/dlss.cu
@@ -52,7 +52,6 @@ static_assert(false, "DLSS can only be compiled when both Vulkan and GUI support
 
 using namespace Eigen;
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 

--- a/src/main.cu
+++ b/src/main.cu
@@ -176,6 +176,8 @@ int main_func(const std::vector<std::string>& arguments) {
 			tlog::info() << "iteration=" << testbed.m_training_step << " loss=" << testbed.m_loss_scalar.val();
 		}
 	}
+
+	return 0;
 }
 
 NGP_NAMESPACE_END

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -23,6 +23,8 @@
 
 #include <filesystem/path.h>
 
+#include <stb_image/stb_image.h>
+
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <cstdlib>
@@ -31,28 +33,9 @@
 #include <string>
 #include <vector>
 
-#define STB_IMAGE_IMPLEMENTATION
-
-#ifdef __NVCC__
-#  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#    pragma nv_diag_suppress 550
-#  else
-#    pragma diag_suppress 550
-#  endif
-#endif
-#include <stb_image/stb_image.h>
-#ifdef __NVCC__
-#  ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#    pragma nv_diag_default 550
-#  else
-#    pragma diag_default 550
-#  endif
-#endif
-
 using namespace tcnn;
 using namespace std::literals;
 using namespace Eigen;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -284,7 +267,7 @@ bool read_focal_length(const nlohmann::json &json, Vector2f &focal_length, const
 	return true;
 }
 
-NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float sharpen_amount) {
+NerfDataset load_nerf(const std::vector<fs::path>& jsonpaths, float sharpen_amount) {
 	if (jsonpaths.empty()) {
 		throw std::runtime_error{"Cannot load NeRF data from an empty set of paths."};
 	}
@@ -293,7 +276,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 
 	NerfDataset result{};
 
-	std::ifstream f{jsonpaths.front().str()};
+	std::ifstream f{native_string(jsonpaths.front())};
 	nlohmann::json transforms = nlohmann::json::parse(f, nullptr, true, true);
 
 	ThreadPool pool;
@@ -322,7 +305,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 	std::transform(
 		jsonpaths.begin(), jsonpaths.end(),
 		std::back_inserter(jsons), [](const auto& path) {
-			return nlohmann::json::parse(std::ifstream{path.str()}, nullptr, true, true);
+			return nlohmann::json::parse(std::ifstream{native_string(path)}, nullptr, true, true);
 		}
 	);
 
@@ -546,10 +529,10 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 			}
 
 			if (equals_case_insensitive(envmap_path.extension(), "exr")) {
-				result.envmap_data = load_exr(envmap_path.str(), result.envmap_resolution.x(), result.envmap_resolution.y());
+				result.envmap_data = load_exr_gpu(envmap_path, &result.envmap_resolution.x(), &result.envmap_resolution.y());
 				result.is_hdr = true;
 			} else {
-				result.envmap_data = load_stbi(envmap_path.str(), result.envmap_resolution.x(), result.envmap_resolution.y());
+				result.envmap_data = load_stbi_gpu(envmap_path, &result.envmap_resolution.x(), &result.envmap_resolution.y());
 			}
 		}
 
@@ -580,7 +563,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 				result.is_hdr = true;
 			} else {
 				dst.image_data_on_gpu = false;
-				uint8_t* img = stbi_load(path.str().c_str(), &dst.res.x(), &dst.res.y(), &comp, 4);
+				uint8_t* img = load_stbi(path, &dst.res.x(), &dst.res.y(), &comp, 4);
 				if (!img) {
 					throw std::runtime_error{"Could not open image file: "s + std::string{stbi_failure_reason()}};
 				}
@@ -588,7 +571,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 				fs::path alphapath = resolve_path(base_path, fmt::format("{}.alpha.{}", frame["file_path"], path.extension()));
 				if (alphapath.exists()) {
 					int wa = 0, ha = 0;
-					uint8_t* alpha_img = stbi_load(alphapath.str().c_str(), &wa, &ha, &comp, 4);
+					uint8_t* alpha_img = load_stbi(alphapath, &wa, &ha, &comp, 4);
 					if (!alpha_img) {
 						throw std::runtime_error{"Could not load alpha image "s + alphapath.str()};
 					}
@@ -607,7 +590,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 				fs::path maskpath = path.parent_path() / fmt::format("dynamic_mask_{}.png", path.basename());
 				if (maskpath.exists()) {
 					int wa = 0, ha = 0;
-					uint8_t* mask_img = stbi_load(maskpath.str().c_str(), &wa, &ha, &comp, 4);
+					uint8_t* mask_img = load_stbi(maskpath, &wa, &ha, &comp, 4);
 					if (!mask_img) {
 						throw std::runtime_error{fmt::format("Dynamic mask {} could not be loaded.", maskpath.str())};
 					}
@@ -637,7 +620,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 				fs::path depthpath = resolve_path(base_path, frame["depth_path"]);
 				if (depthpath.exists()) {
 					int wa = 0, ha = 0;
-					dst.depth_pixels = stbi_load_16(depthpath.str().c_str(), &wa, &ha, &comp, 1);
+					dst.depth_pixels = load_stbi_16(depthpath, &wa, &ha, &comp, 1);
 					if (!dst.depth_pixels) {
 						throw std::runtime_error{fmt::format("Could not load depth image '{}'.", depthpath.str())};
 					}
@@ -653,7 +636,7 @@ NerfDataset load_nerf(const std::vector<filesystem::path>& jsonpaths, float shar
 				uint32_t n_pixels = dst.res.prod();
 				dst.rays = (Ray*)malloc(n_pixels * sizeof(Ray));
 
-				std::ifstream rays_file{rayspath.str(), std::ios::binary};
+				std::ifstream rays_file{native_string(rayspath), std::ios::binary};
 				rays_file.read((char*)dst.rays, n_pixels * sizeof(Ray));
 
 				std::streampos fsize = 0;

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -326,11 +326,18 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("max", &BoundingBox::max)
 		;
 
+	py::class_<fs::path>(m, "path")
+		.def(py::init<>())
+		.def(py::init<const std::string&>())
+		;
+
+	py::implicitly_convertible<std::string, fs::path>();
+
 	py::class_<Testbed> testbed(m, "Testbed");
 	testbed
 		.def(py::init<ETestbedMode>(), py::arg("mode") = ETestbedMode::None)
-		.def(py::init<ETestbedMode, const std::string&, const std::string&>())
-		.def(py::init<ETestbedMode, const std::string&, const json&>())
+		.def(py::init<ETestbedMode, const fs::path&, const fs::path&>())
+		.def(py::init<ETestbedMode, const fs::path&, const json&>())
 		.def_readonly("mode", &Testbed::m_testbed_mode)
 		.def("create_empty_nerf_dataset", &Testbed::create_empty_nerf_dataset, "Allocate memory for a nerf dataset with a given size", py::arg("n_images"), py::arg("aabb_scale")=1, py::arg("is_hdr")=false)
 		.def("load_training_data", &Testbed::load_training_data, py::call_guard<py::gil_scoped_release>(), "Load training data from a given path.")
@@ -387,8 +394,8 @@ PYBIND11_MODULE(pyngp, m) {
 		.def("n_encoding_params", &Testbed::n_encoding_params, "Number of trainable parameters in the encoding")
 		.def("save_snapshot", &Testbed::save_snapshot, py::arg("path"), py::arg("include_optimizer_state")=false, py::arg("compress")=true, "Save a snapshot of the currently trained model. Optionally compressed (only when saving '.ingp' files).")
 		.def("load_snapshot", &Testbed::load_snapshot, py::arg("path"), "Load a previously saved snapshot")
-		.def("load_camera_path", &Testbed::load_camera_path, "Load a camera path", py::arg("path"))
-		.def("load_file", &Testbed::load_file, "Load a file and automatically determine how to handle it. Can be a snapshot, dataset, network config, or camera path.", py::arg("path"))
+		.def("load_camera_path", &Testbed::load_camera_path, py::arg("path"), "Load a camera path")
+		.def("load_file", &Testbed::load_file, py::arg("path"), "Load a file and automatically determine how to handle it. Can be a snapshot, dataset, network config, or camera path.")
 		.def_property("loop_animation", &Testbed::loop_animation, &Testbed::set_loop_animation)
 		.def("compute_and_save_png_slices", &Testbed::compute_and_save_png_slices,
 			py::arg("filename"),

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -35,7 +35,6 @@
 
 using namespace Eigen;
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -117,10 +116,10 @@ void GLTexture::blit_from_cuda_mapping() {
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, m_size.x(), m_size.y(), 0, GL_RGBA, GL_FLOAT, data_cpu);
 }
 
-void GLTexture::load(const char* fname) {
+void GLTexture::load(const fs::path& path) {
 	uint8_t* out; // width * height * RGBA
-	int comp,width,height;
-	out = stbi_load(fname, &width, &height, &comp, 4);
+	int comp, width, height;
+	out = load_stbi(path, &width, &height, &comp, 4);
 	if (!out) {
 		throw std::runtime_error{std::string{stbi_failure_reason()}};
 	}
@@ -161,7 +160,7 @@ void GLTexture::resize(const Vector2i& new_size, int n_channels, bool is_8bit) {
 		case 2: m_internal_format = is_8bit ? GL_RG8   : GL_RG32F;   m_format = GL_RG;   break;
 		case 3: m_internal_format = is_8bit ? GL_RGB8  : GL_RGB32F;  m_format = GL_RGB;  break;
 		case 4: m_internal_format = is_8bit ? GL_RGBA8 : GL_RGBA32F; m_format = GL_RGBA; break;
-		default: tlog::error() << "Unsupported number of channels: " << n_channels;
+		default: throw std::runtime_error{fmt::format("GLTexture: unsupported number of channels {}", n_channels)};
 	}
 	m_is_8bit = is_8bit;
 	m_size = new_size;

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -40,7 +40,6 @@
 
 using namespace Eigen;
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -2462,8 +2461,8 @@ void Testbed::Nerf::Training::reset_camera_extrinsics() {
 	}
 }
 
-void Testbed::Nerf::Training::export_camera_extrinsics(const std::string& filename, bool export_extrinsics_in_quat_format) {
-	tlog::info() << "Saving a total of " << n_images_for_training << " poses to " << filename;
+void Testbed::Nerf::Training::export_camera_extrinsics(const fs::path& path, bool export_extrinsics_in_quat_format) {
+	tlog::info() << "Saving a total of " << n_images_for_training << " poses to " << path.str();
 	nlohmann::json trajectory;
 	for(int i = 0; i < n_images_for_training; ++i) {
 		nlohmann::json frame{{"id", i}};
@@ -2495,7 +2494,8 @@ void Testbed::Nerf::Training::export_camera_extrinsics(const std::string& filena
 
 		trajectory.emplace_back(frame);
 	}
-	std::ofstream file(filename);
+
+	std::ofstream file{native_string(path)};
 	file << std::setw(2) << trajectory << std::endl;
 }
 

--- a/src/testbed_sdf.cu
+++ b/src/testbed_sdf.cu
@@ -32,7 +32,6 @@
 
 using namespace Eigen;
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -1018,23 +1017,23 @@ void Testbed::render_sdf(
 	}
 }
 
-std::vector<Vector3f> load_stl(const std::string& filename) {
+std::vector<Vector3f> load_stl(const fs::path& path) {
 	std::vector<Vector3f> vertices;
 
-	std::ifstream f{filename, std::ios::in | std::ios::binary};
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
 	if (!f) {
-		throw std::runtime_error{fmt::format("Mesh file '{}' not found", filename)};
+		throw std::runtime_error{fmt::format("Mesh file '{}' not found", path.str())};
 	}
 
 	uint32_t buf[21] = {};
 	f.read((char*)buf, 4 * 21);
 	if (f.gcount() < 4 * 21) {
-		throw std::runtime_error{fmt::format("Mesh file '{}' too small for STL header", filename)};
+		throw std::runtime_error{fmt::format("Mesh file '{}' too small for STL header", path.str())};
 	}
 
 	uint32_t nfaces = buf[20];
 	if (memcmp(buf, "solid", 5) == 0 || buf[20] == 0) {
-		throw std::runtime_error{fmt::format("ASCII STL file '{}' not supported", filename)};
+		throw std::runtime_error{fmt::format("ASCII STL file '{}' not supported", path.str())};
 	}
 
 	vertices.reserve(nfaces * 3);

--- a/src/testbed_volume.cu
+++ b/src/testbed_volume.cu
@@ -33,7 +33,6 @@
 
 using namespace Eigen;
 using namespace tcnn;
-namespace fs = filesystem;
 
 NGP_NAMESPACE_BEGIN
 
@@ -555,7 +554,7 @@ void Testbed::load_volume(const fs::path& data_path) {
 		throw std::runtime_error{data_path.str() + " does not exist."};
 	}
 	tlog::info() << "Loading NanoVDB file from " << data_path;
-	std::ifstream f(data_path.str(), std::ios::in | std::ios::binary);
+	std::ifstream f{native_string(data_path), std::ios::in | std::ios::binary};
 	NanoVDBFileHeader header;
 	NanoVDBMetaData metadata;
 	f.read(reinterpret_cast<char*>(&header), sizeof(header));

--- a/src/tinyobj_loader_wrapper.cpp
+++ b/src/tinyobj_loader_wrapper.cpp
@@ -29,7 +29,7 @@ using namespace Eigen;
 
 NGP_NAMESPACE_BEGIN
 
-std::vector<Vector3f> load_obj(const std::string& filename) {
+std::vector<Vector3f> load_obj(const fs::path& path) {
 	tinyobj::attrib_t attrib;
 	std::vector<tinyobj::shape_t> shapes;
 	std::vector<tinyobj::material_t> materials;
@@ -37,19 +37,20 @@ std::vector<Vector3f> load_obj(const std::string& filename) {
 	std::string warn;
 	std::string err;
 
-	bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, filename.c_str());
+	std::ifstream f{native_string(path), std::ios::in | std::ios::binary};
+	bool ret = tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, &f);
 
 	if (!warn.empty()) {
-		tlog::warning() << warn << " while loading '" << filename << "'";
+		tlog::warning() << warn << " while loading '" << path.str() << "'";
 	}
 
 	if (!err.empty()) {
-		throw std::runtime_error{fmt::format("Error loading '{}': {}", filename, err)};
+		throw std::runtime_error{fmt::format("Error loading '{}': {}", path.str(), err)};
 	}
 
 	std::vector<Vector3f> result;
 
-	tlog::success() << "Loaded mesh \"" << filename << "\" file with " << shapes.size() << " shapes.";
+	tlog::success() << "Loaded mesh \"" << path.str() << "\" file with " << shapes.size() << " shapes.";
 
 	// Loop over shapes
 	for (size_t s = 0; s < shapes.size(); s++) {
@@ -59,7 +60,7 @@ std::vector<Vector3f> load_obj(const std::string& filename) {
 			size_t fv = size_t(shapes[s].mesh.num_face_vertices[f]);
 
 			if (shapes[s].mesh.num_face_vertices[f] != 3) {
-				tlog::warning() << "Non-triangle face found in " << filename;
+				tlog::warning() << "Non-triangle face found in " << path.str();
 				index_offset += fv;
 				continue;
 			}


### PR DESCRIPTION
This PR switches all path handling to unicode-agnostic mechanisms. Internally, __instant-ngp__ used UTF8 encoded strings.

When running Windows, the appropriate conversion to UTF16 is carried out upon opening a file handle or executing a system command.

The Windows terminal will now also render unicode characters correctly.

On Linux, unicode was previously supported already if UTF8 strings were passed.