### PR TITLE
Modify the thread's work logic

### DIFF
--- a/include/neural-graphics-primitives/thread_pool.h
+++ b/include/neural-graphics-primitives/thread_pool.h
@@ -48,7 +48,7 @@ public:
 		{
 			std::lock_guard<std::mutex> lock{m_task_queue_mutex};
 
-			if (high_priority) {
+			if (high_priority || m_ready_to_exit) {
 				m_task_queue.emplace_front([task]() { (*task)(); });
 			} else {
 				m_task_queue.emplace_back([task]() { (*task)(); });
@@ -99,6 +99,7 @@ private:
 	size_t m_num_threads = 0;
 	std::vector<std::thread> m_threads;
 
+	bool m_ready_to_exit = false;
 	std::deque<std::function<void()>> m_task_queue;
 	std::mutex m_task_queue_mutex;
 	std::condition_variable m_worker_condition;

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -47,7 +47,7 @@ void ThreadPool::start_threads(size_t num) {
 					m_worker_condition.wait(lock);
 				}
 
-				if (i >= m_num_threads) {
+				if (i >= m_num_threads && m_task_queue.empty()) {
 					break;
 				}
 


### PR DESCRIPTION
Avoid situations where the task is exited before it is completed due to the `shutdown_threads`.
On my computer, the output below is 1949, however the correct answer should be 20000
```
std::atomic<int> data{0};
{
    ThreadPool pool;
    pool.parallel_for(0,20000,[&](auto){
        pool.enqueue_task([&data]{data++;});
    });
}
spdlog::info("data = {}",data);
```