### PR TITLE
Switch from `Eigen` to `glm` for vector math (and a few bugfixes / improvements)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "dependencies/pybind11"]
 	path = dependencies/pybind11
 	url = https://github.com/Tom94/pybind11
-[submodule "dependencies/eigen"]
-	path = dependencies/eigen
-	url = https://github.com/Tom94/eigen
 [submodule "dependencies/glfw"]
 	path = dependencies/glfw
 	url = https://github.com/Tom94/glfw
@@ -31,3 +28,6 @@
 [submodule "dependencies/OpenXR-SDK"]
 	path = dependencies/OpenXR-SDK
 	url = https://github.com/KhronosGroup/OpenXR-SDK.git
+[submodule "dependencies/glm"]
+	path = dependencies/glm
+	url = https://github.com/g-truc/glm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if (MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP24")
 else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
@@ -75,10 +76,12 @@ if (MSVC)
 else()
 	list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-Wno-float-conversion")
 	list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fno-strict-aliasing")
+	list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fms-extensions")
 	list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-fPIC")
 endif()
 list(APPEND CUDA_NVCC_FLAGS "--extended-lambda")
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
 
 ###############################################################################
 # Dependencies
@@ -199,8 +202,8 @@ endif(NGP_BUILD_WITH_GUI)
 
 list(APPEND NGP_INCLUDE_DIRECTORIES
 	"dependencies"
-	"dependencies/eigen"
 	"dependencies/filesystem"
+	"dependencies/glm"
 	"dependencies/nanovdb"
 	"dependencies/NaturalSort"
 	"dependencies/tinylogger"

--- a/configs/nerf/base.json
+++ b/configs/nerf/base.json
@@ -22,8 +22,8 @@
 	},
 	"encoding": {
 		"otype": "HashGrid",
-		"n_levels": 16,
-		"n_features_per_level": 2,
+		"n_levels": 6,
+		"n_features_per_level": 8,
 		"log2_hashmap_size": 19,
 		"base_resolution": 16
 	},

--- a/configs/nerf/base.json
+++ b/configs/nerf/base.json
@@ -22,8 +22,8 @@
 	},
 	"encoding": {
 		"otype": "HashGrid",
-		"n_levels": 6,
-		"n_features_per_level": 8,
+		"n_levels": 8,
+		"n_features_per_level": 4,
 		"log2_hashmap_size": 19,
 		"base_resolution": 16
 	},

--- a/dependencies/pybind11_glm/pybind11_glm.hpp
+++ b/dependencies/pybind11_glm/pybind11_glm.hpp
@@ -1,0 +1,262 @@
+/*
+    utils/pybind11_glm.hpp: Transparent conversion for glm types to NumPy arrays.
+                            This header is based on pybind11/eigen.h.
+
+    Copyright (c) 2016 Patrik Huber
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in pybind11's LICENSE file.
+*/
+#pragma once
+
+#include <cstddef>
+
+#include <pybind11/numpy.h>
+
+#include <glm/gtc/type_ptr.hpp> // includes all vector and matrix types too
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4127) // warning C4127: Conditional expression is constant
+#endif
+
+NAMESPACE_BEGIN(pybind11)
+NAMESPACE_BEGIN(detail)
+
+/**
+ * @file utils/pybind11_glm.hpp
+ * @brief Transparent conversion to and from Python for glm vector and matrix types.
+ *
+ * All converters for matrices assume col-major storage of glm, the default.
+ * Things will likely break if non-default storage order is used.
+ */
+
+template <typename T, glm::precision P>
+struct type_caster<glm::tvec2<T, P>>
+{
+	using vector_type = glm::tvec2<T, P>;
+	using Scalar = T;
+	static constexpr std::size_t num_elements = 2;
+
+	bool load(handle src, bool)
+	{
+		array_t<Scalar> buf(src, true);
+		if (!buf.check())
+			return false;
+
+		if (buf.ndim() == 1) // a 1-dimensional vector
+		{
+			if (buf.shape(0) != num_elements) {
+				return false; // not a 2-elements vector
+			}
+			if (buf.strides(0) != sizeof(Scalar))
+			{
+				std::cout << "An array with non-standard strides is given. Please pass a contiguous array." << std::endl;
+				return false;
+			}
+			value = glm::make_vec2(buf.mutable_data()); // make_vec* copies the data (unnecessarily)
+		}
+		else { // buf.ndim() != 1
+			return false;
+		}
+		return true;
+	}
+
+	static handle cast(const vector_type& src, return_value_policy /* policy */, handle /* parent */)
+	{
+		return array(
+			num_elements,			// shape
+			glm::value_ptr(src)		// data
+		).release();
+	}
+
+	// Specifies the doc-string for the type in Python:
+	PYBIND11_TYPE_CASTER(vector_type, _("vec2"));
+};
+
+template<typename T, glm::precision P>
+struct type_caster<glm::tvec3<T, P>>
+{
+	using vector_type = glm::tvec3<T, P>;
+	using Scalar = T;
+	static constexpr std::size_t num_elements = 3;
+
+	bool load(handle src, bool)
+	{
+		array_t<Scalar> buf(src, true);
+		if (!buf.check())
+			return false;
+
+		if (buf.ndim() == 1) // a 1-dimensional vector
+		{
+			if (buf.shape(0) != num_elements) {
+				return false; // not a 3-elements vector
+			}
+			if (buf.strides(0) != sizeof(Scalar))
+			{
+				std::cout << "An array with non-standard strides is given. Please pass a contiguous array." << std::endl;
+				return false;
+			}
+			value = glm::make_vec3(buf.mutable_data()); // make_vec* copies the data (unnecessarily)
+		}
+		else { // buf.ndim() != 1
+			return false;
+		}
+		return true;
+	}
+
+	static handle cast(const vector_type& src, return_value_policy /* policy */, handle /* parent */)
+	{
+		return array(
+			num_elements,			// shape
+			glm::value_ptr(src)		// data
+		).release();
+	}
+
+	// Specifies the doc-string for the type in Python:
+	PYBIND11_TYPE_CASTER(vector_type, _("vec3"));
+};
+
+template<typename T, glm::precision P>
+struct type_caster<glm::tvec4<T, P>>
+{
+	using vector_type = glm::tvec4<T, P>;
+	using Scalar = T;
+	static constexpr std::size_t num_elements = 4;
+
+	bool load(handle src, bool)
+	{
+		array_t<Scalar> buf(src, true);
+		if (!buf.check())
+			return false;
+
+		if (buf.ndim() == 1) // a 1-dimensional vector
+		{
+			if (buf.shape(0) != num_elements) {
+				return false; // not a 4-elements vector
+			}
+			if (buf.strides(0) != sizeof(Scalar))
+			{
+				std::cout << "An array with non-standard strides is given. Please pass a contiguous array." << std::endl;
+				return false;
+			}
+			value = glm::make_vec4(buf.mutable_data()); // make_vec* copies the data (unnecessarily)
+		}
+		else { // buf.ndim() != 1
+			return false;
+		}
+		return true;
+	}
+
+	static handle cast(const vector_type& src, return_value_policy /* policy */, handle /* parent */)
+	{
+		return array(
+			num_elements,			// shape
+			glm::value_ptr(src)		// data
+		).release();
+	}
+
+	// Specifies the doc-string for the type in Python:
+	PYBIND11_TYPE_CASTER(vector_type, _("vec4"));
+};
+
+template<typename T, glm::precision P>
+struct type_caster<glm::tmat4x3<T, P>>
+{
+	using matrix_type = glm::tmat4x3<T, P>;
+	using Scalar = T;
+	static constexpr std::size_t num_rows = 3;
+	static constexpr std::size_t num_cols = 4;
+
+	bool load(handle src, bool)
+	{
+		array_t<Scalar> buf(src, true);
+		if (!buf.check())
+			return false;
+
+		if (buf.ndim() == 2) // a 2-dimensional matrix
+		{
+			if (buf.shape(0) != num_rows || buf.shape(1) != num_cols) {
+				return false; // not a 4x4 matrix
+			}
+			if (buf.strides(0) / sizeof(Scalar) != num_cols || buf.strides(1) != sizeof(Scalar))
+			{
+				std::cout << "An array with non-standard strides is given. Please pass a contiguous array." << std::endl;
+				return false;
+			}
+			// What we get from Python is laid out in row-major memory order, while GLM's
+			// storage is col-major, thus, we transpose.
+			value = glm::transpose(glm::make_mat3x4(buf.mutable_data())); // make_mat*() copies the data (unnecessarily)
+		}
+		else { // buf.ndim() != 2
+			return false;
+		}
+		return true;
+	}
+
+	static handle cast(const matrix_type& src, return_value_policy /* policy */, handle /* parent */)
+	{
+		return array(
+			{ num_rows, num_cols }, // shape
+			{ sizeof(Scalar), sizeof(Scalar) * num_rows }, // strides - flip the row/col layout!
+			glm::value_ptr(src)                            // data
+		).release();
+	}
+
+	// Specifies the doc-string for the type in Python:
+	PYBIND11_TYPE_CASTER(matrix_type, _("mat4x3"));
+};
+
+template<typename T, glm::precision P>
+struct type_caster<glm::tmat4x4<T, P>>
+{
+	using matrix_type = glm::tmat4x4<T, P>;
+	using Scalar = T;
+	static constexpr std::size_t num_rows = 4;
+	static constexpr std::size_t num_cols = 4;
+
+	bool load(handle src, bool)
+	{
+		array_t<Scalar> buf(src, true);
+		if (!buf.check())
+			return false;
+
+		if (buf.ndim() == 2) // a 2-dimensional matrix
+		{
+			if (buf.shape(0) != num_rows || buf.shape(1) != num_cols) {
+				return false; // not a 4x4 matrix
+			}
+			if (buf.strides(0) / sizeof(Scalar) != num_cols || buf.strides(1) != sizeof(Scalar))
+			{
+				std::cout << "An array with non-standard strides is given. Please pass a contiguous array." << std::endl;
+				return false;
+			}
+			// What we get from Python is laid out in row-major memory order, while GLM's
+			// storage is col-major, thus, we transpose.
+			value = glm::transpose(glm::make_mat4x4(buf.mutable_data())); // make_mat*() copies the data (unnecessarily)
+		}
+		else { // buf.ndim() != 2
+			return false;
+		}
+		return true;
+	}
+
+	static handle cast(const matrix_type& src, return_value_policy /* policy */, handle /* parent */)
+	{
+		return array(
+			{ num_rows, num_cols }, // shape
+			{ sizeof(Scalar), sizeof(Scalar) * num_rows }, // strides - flip the row/col layout!
+			glm::value_ptr(src)                            // data
+		).release();
+	}
+
+	// Specifies the doc-string for the type in Python:
+	PYBIND11_TYPE_CASTER(matrix_type, _("mat4x4"));
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(pybind11)
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/docs/nerf_dataset_tips.md
+++ b/docs/nerf_dataset_tips.md
@@ -43,7 +43,7 @@ If you have an existing dataset in `transforms.json` format, it should be center
 You can set any of the following parameters, where the listed values are the default.
 ```json
 {
-	"aabb_scale": 64,
+	"aabb_scale": 32,
 	"scale": 0.33,
 	"offset": [0.5, 0.5, 0.5],
 	...	
@@ -102,7 +102,7 @@ If you use Windows, you do not need to install anything. COLMAP and FFmpeg will 
 If you are training from a video file, run the [scripts/colmap2nerf.py](/scripts/colmap2nerf.py) script from the folder containing the video, with the following recommended parameters:
 
 ```sh
-data-folder$ python [path-to-instant-ngp]/scripts/colmap2nerf.py --video_in <filename of video> --video_fps 2 --run_colmap --aabb_scale 64
+data-folder$ python [path-to-instant-ngp]/scripts/colmap2nerf.py --video_in <filename of video> --video_fps 2 --run_colmap --aabb_scale 32
 ```
 
 The above assumes a single video file as input, which then has frames extracted at the specified framerate (2). It is recommended to choose a frame rate that leads to around 50-150 images. So for a one minute video, `--video_fps 2` is ideal.
@@ -110,7 +110,7 @@ The above assumes a single video file as input, which then has frames extracted 
 For training from images, place them in a subfolder called `images` and then use suitable options such as the ones below:
 
 ```sh
-data-folder$ python [path-to-instant-ngp]/scripts/colmap2nerf.py --colmap_matcher exhaustive --run_colmap --aabb_scale 64
+data-folder$ python [path-to-instant-ngp]/scripts/colmap2nerf.py --colmap_matcher exhaustive --run_colmap --aabb_scale 32
 ```
 
 The script will run (and install, if you use Windows) FFmpeg and COLMAP as needed, followed by a conversion step to the required `transforms.json` format, which will be written in the current directory. 

--- a/docs/nerf_dataset_tips.md
+++ b/docs/nerf_dataset_tips.md
@@ -65,7 +65,6 @@ to `transforms.json`:
 ```
 where `16` is a well-performing default number, but others can be also experimented with.
 
-
 ## Preparing new NeRF datasets
 
 To train on self-captured data, one has to process the data into an existing format supported by __instant-ngp__. We provide scripts to support three approaches:

--- a/include/neural-graphics-primitives/adam_optimizer.h
+++ b/include/neural-graphics-primitives/adam_optimizer.h
@@ -15,13 +15,120 @@
 #pragma once
 
 #include <neural-graphics-primitives/common.h>
+#include <neural-graphics-primitives/common_device.cuh>
+#include <neural-graphics-primitives/json_binding.h>
+
+#include <json/json.hpp>
 
 NGP_NAMESPACE_BEGIN
+
+class VarAdamOptimizer {
+public:
+	VarAdamOptimizer(size_t size = 0, float learning_rate = 1e-3, float epsilon = 1e-08f, float beta1 = 0.9f, float beta2 = 0.99f) : m_state{size} {
+		m_hparams = { learning_rate, epsilon, beta1, beta2 };
+	}
+
+	VarAdamOptimizer& operator=(const VarAdamOptimizer& arg) {
+		m_state = arg.m_state;
+		m_hparams = arg.m_hparams;
+		return *this;
+	}
+
+	VarAdamOptimizer(const VarAdamOptimizer& arg) {
+		*this = arg;
+	}
+
+	void step(const std::vector<float>& gradient) {
+		++m_state.iter;
+
+		float actual_learning_rate = m_hparams.learning_rate * std::sqrt(1.0f - std::pow(m_hparams.beta2, (float)m_state.iter)) / (1.0f - std::pow(m_hparams.beta1, (float)m_state.iter));
+
+		for (size_t i = 0; i < m_state.first_moment.size(); ++i) {
+			m_state.first_moment[i] = m_hparams.beta1 * m_state.first_moment[i] + (1.0f - m_hparams.beta1) * gradient[i];
+			m_state.second_moment[i] = m_hparams.beta2 * m_state.second_moment[i] + (1.0f - m_hparams.beta2) * gradient[i] * gradient[i];
+			m_state.variable[i] -= actual_learning_rate * m_state.first_moment[i] / (std::sqrt(m_state.second_moment[i]) + m_hparams.epsilon);
+		}
+	}
+
+	uint32_t step() const {
+		return m_state.iter;
+	}
+
+	void set_learning_rate(float lr) {
+		m_hparams.learning_rate = lr;
+	}
+
+	std::vector<float>& variable() {
+		return m_state.variable;
+	}
+
+	const std::vector<float>& variable() const {
+		return m_state.variable;
+	}
+
+	void reset_state() {
+		m_state = State{m_state.first_moment.size()};
+	}
+
+	void to_json(nlohmann::json& j) const {
+		j["iter"] = m_state.iter;
+		j["first_moment"] = m_state.first_moment;
+		j["second_moment"] = m_state.second_moment;
+		j["variable"] = m_state.variable;
+		j["learning_rate"] = m_hparams.learning_rate;
+		j["epsilon"] = m_hparams.epsilon;
+		j["beta1"] = m_hparams.beta1;
+		j["beta2"] = m_hparams.beta2;
+	}
+
+	void from_json(const nlohmann::json& j) {
+		m_state.iter = j.at("iter");
+		m_state.first_moment = j.at("first_moment").get<std::vector<float>>();
+		m_state.second_moment = j.at("second_moment").get<std::vector<float>>();
+		m_state.variable = j.at("variable").get<std::vector<float>>();
+		m_hparams.learning_rate = j.at("learning_rate");
+		m_hparams.epsilon = j.at("epsilon");
+		m_hparams.beta1 = j.at("beta1");
+		m_hparams.beta2 = j.at("beta2");
+	}
+
+private:
+	struct State {
+		State() = default;
+		State(const State&) = default;
+		State(size_t size) {
+			iter = 0;
+			first_moment = std::vector<float>(size, 0.0f);
+			second_moment = std::vector<float>(size, 0.0f);
+			variable = std::vector<float>(size, 0.0f);
+		}
+
+		uint32_t iter;
+		std::vector<float> first_moment;
+		std::vector<float> second_moment;
+		std::vector<float> variable;
+	} m_state;
+
+	struct Hyperparameters {
+		float learning_rate;
+		float epsilon;
+		float beta1;
+		float beta2;
+	} m_hparams;
+};
+
+inline void to_json(nlohmann::json& j, const VarAdamOptimizer& opt) {
+	opt.to_json(j);
+}
+
+inline void from_json(const nlohmann::json& j, VarAdamOptimizer& opt) {
+	opt.from_json(j);
+}
 
 template <typename T>
 class AdamOptimizer {
 public:
-	AdamOptimizer(float learning_rate, const T& zero = T::Zero(), float epsilon = 1e-08f, float beta1 = 0.9f, float beta2 = 0.99f) : m_state(zero) {
+	AdamOptimizer(float learning_rate = 1e-3, float epsilon = 1e-08f, float beta1 = 0.9f, float beta2 = 0.99f) {
 		m_hparams = { learning_rate, epsilon, beta1, beta2 };
 	}
 
@@ -38,10 +145,10 @@ public:
 	void step(const T& gradient) {
 		++m_state.iter;
 
-		float actual_learning_rate = m_hparams.learning_rate * std::sqrt(1 - std::pow(m_hparams.beta2, (float)m_state.iter)) / (1 - std::pow(m_hparams.beta1, (float)m_state.iter));
-		m_state.first_moment = m_hparams.beta1 * m_state.first_moment + (1 - m_hparams.beta1) * gradient;
-		m_state.second_moment = m_hparams.beta2 * m_state.second_moment + (1 - m_hparams.beta2) * gradient.cwiseProduct(gradient);
-		m_state.variable -= actual_learning_rate * m_state.first_moment.cwiseQuotient(m_state.second_moment.cwiseSqrt() + T::Constant(m_state.variable.size(), m_hparams.epsilon));
+		float actual_learning_rate = m_hparams.learning_rate * std::sqrt(1.0f - std::pow(m_hparams.beta2, (float)m_state.iter)) / (1.0f - std::pow(m_hparams.beta1, (float)m_state.iter));
+		m_state.first_moment = m_hparams.beta1 * m_state.first_moment + (1.0f - m_hparams.beta1) * gradient;
+		m_state.second_moment = m_hparams.beta2 * m_state.second_moment + (1.0f - m_hparams.beta2) * gradient * gradient;
+		m_state.variable -= actual_learning_rate * m_state.first_moment / (sqrt(m_state.second_moment) + T(m_hparams.epsilon));
 	}
 
 	uint32_t step() const {
@@ -60,39 +167,61 @@ public:
 		return m_state.variable;
 	}
 
-	void reset_state(const T& zero = T::Zero()) {
-		m_state = State(zero);
+	void reset_state() {
+		m_state = {};
+	}
+
+	void to_json(nlohmann::json& j) const {
+		j["iter"] = m_state.iter;
+		j["first_moment"] = m_state.first_moment;
+		j["second_moment"] = m_state.second_moment;
+		j["variable"] = m_state.variable;
+		j["learning_rate"] = m_hparams.learning_rate;
+		j["epsilon"] = m_hparams.epsilon;
+		j["beta1"] = m_hparams.beta1;
+		j["beta2"] = m_hparams.beta2;
+	}
+
+	void from_json(const nlohmann::json& j) {
+		m_state.iter = j.at("iter");
+		m_state.first_moment = j.at("first_moment");
+		m_state.second_moment = j.at("second_moment");
+		m_state.variable = j.at("variable");
+		m_hparams.learning_rate = j.at("learning_rate");
+		m_hparams.epsilon = j.at("epsilon");
+		m_hparams.beta1 = j.at("beta1");
+		m_hparams.beta2 = j.at("beta2");
 	}
 
 private:
 	struct State {
-		State() = default;
-		State(const State&) = default;
-
-		State(const T& zero) {
-			iter = 0;
-			first_moment = zero;
-			second_moment = zero;
-			variable = zero;
-		}
-
-		uint32_t iter;
-		T first_moment;
-		T second_moment;
-		T variable;
-	} m_state;
+		uint32_t iter = 0;
+		T first_moment = T(0.0f);
+		T second_moment = T(0.0f);
+		T variable = T(0.0f);
+	} m_state = {};
 
 	struct Hyperparameters {
 		float learning_rate;
 		float epsilon;
 		float beta1;
 		float beta2;
-	} m_hparams;
+	} m_hparams = {};
 };
+
+template <typename T>
+inline void to_json(nlohmann::json& j, const AdamOptimizer<T>& opt) {
+	opt.to_json(j);
+}
+
+template <typename T>
+inline void from_json(const nlohmann::json& j, AdamOptimizer<T>& opt) {
+	opt.from_json(j);
+}
 
 class RotationAdamOptimizer {
 public:
-	RotationAdamOptimizer(float learning_rate, float epsilon = 1e-08f, float beta1 = 0.9f, float beta2 = 0.99f) {
+	RotationAdamOptimizer(float learning_rate = 1e-3, float epsilon = 1e-08f, float beta1 = 0.9f, float beta2 = 0.99f) {
 		m_hparams = { learning_rate, epsilon, beta1, beta2 };
 	}
 
@@ -106,22 +235,15 @@ public:
 		*this = arg;
 	}
 
-	void step(const Eigen::Vector3f& gradient) {
+	void step(const vec3& gradient) {
 		++m_state.iter;
 
 		float actual_learning_rate = m_hparams.learning_rate * std::sqrt(1 - std::pow(m_hparams.beta2, m_state.iter)) / (1 - std::pow(m_hparams.beta1, m_state.iter));
 		m_state.first_moment = m_hparams.beta1 * m_state.first_moment + (1 - m_hparams.beta1) * gradient;
-		m_state.second_moment = m_hparams.beta2 * m_state.second_moment + (1 - m_hparams.beta2) * gradient.cwiseProduct(gradient);
-		Eigen::Vector3f rot = actual_learning_rate * m_state.first_moment.cwiseQuotient(m_state.second_moment.cwiseSqrt() + Eigen::Vector3f::Constant(m_hparams.epsilon));
-		float rot_len = rot.norm();
-		float var_len = variable().norm();
+		m_state.second_moment = m_hparams.beta2 * m_state.second_moment + (1 - m_hparams.beta2) * gradient * gradient;
+		vec3 rot = actual_learning_rate * m_state.first_moment / (sqrt(m_state.second_moment) + vec3(m_hparams.epsilon));
 
-		static const Eigen::Vector3f Z = {0.0f, 0.0f, 1.0f};
-
-		Eigen::AngleAxisf result;
-		Eigen::Matrix3f mat = Eigen::AngleAxisf(-rot_len, rot_len > 0 ? rot/rot_len : Z).toRotationMatrix() * Eigen::AngleAxisf(var_len, var_len > 0 ? variable()/var_len : Z).toRotationMatrix();
-		result.fromRotationMatrix(mat);
-		m_state.variable = result.axis() * result.angle();
+		m_state.variable = rotvec(rotmat(-rot) * rotmat(variable()));
 	}
 
 	uint32_t step() const {
@@ -132,7 +254,7 @@ public:
 		m_hparams.learning_rate = lr;
 	}
 
-	const Eigen::Vector3f& variable() const {
+	const vec3& variable() const {
 		return m_state.variable;
 	}
 
@@ -140,12 +262,34 @@ public:
 		m_state = {};
 	}
 
+	void to_json(nlohmann::json& j) const {
+		j["iter"] = m_state.iter;
+		j["first_moment"] = m_state.first_moment;
+		j["second_moment"] = m_state.second_moment;
+		j["variable"] = m_state.variable;
+		j["learning_rate"] = m_hparams.learning_rate;
+		j["epsilon"] = m_hparams.epsilon;
+		j["beta1"] = m_hparams.beta1;
+		j["beta2"] = m_hparams.beta2;
+	}
+
+	void from_json(const nlohmann::json& j) {
+		m_state.iter = j.at("iter");
+		m_state.first_moment = j.at("first_moment");
+		m_state.second_moment = j.at("second_moment");
+		m_state.variable = j.at("variable");
+		m_hparams.learning_rate = j.at("learning_rate");
+		m_hparams.epsilon = j.at("epsilon");
+		m_hparams.beta1 = j.at("beta1");
+		m_hparams.beta2 = j.at("beta2");
+	}
+
 private:
 	struct State {
 		uint32_t iter = 0;
-		Eigen::Vector3f first_moment = Eigen::Vector3f::Zero();
-		Eigen::Vector3f second_moment = Eigen::Vector3f::Zero();
-		Eigen::Vector3f variable = Eigen::Vector3f::Zero();
+		vec3 first_moment = vec3(0.0f);
+		vec3 second_moment = vec3(0.0f);
+		vec3 variable = vec3(0.0f);
 	} m_state;
 
 	struct Hyperparameters {
@@ -155,5 +299,13 @@ private:
 		float beta2;
 	} m_hparams;
 };
+
+inline void to_json(nlohmann::json& j, const RotationAdamOptimizer& opt) {
+	opt.to_json(j);
+}
+
+inline void from_json(const nlohmann::json& j, RotationAdamOptimizer& opt) {
+	opt.from_json(j);
+}
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/bounding_box.cuh
+++ b/include/neural-graphics-primitives/bounding_box.cuh
@@ -22,13 +22,13 @@
 NGP_NAMESPACE_BEGIN
 
 template <int N_POINTS>
-NGP_HOST_DEVICE inline void project(Eigen::Vector3f points[N_POINTS], const Eigen::Vector3f& axis, float& min, float& max) {
+NGP_HOST_DEVICE inline void project(vec3 points[N_POINTS], const vec3& axis, float& min, float& max) {
 	min = std::numeric_limits<float>::infinity();
 	max = -std::numeric_limits<float>::infinity();
 
 	NGP_PRAGMA_UNROLL
 	for (uint32_t i = 0; i < N_POINTS; ++i) {
-		float val = axis.dot(points[i]);
+		float val = dot(axis, points[i]);
 
 		if (val < min) {
 			min = val;
@@ -43,7 +43,7 @@ NGP_HOST_DEVICE inline void project(Eigen::Vector3f points[N_POINTS], const Eige
 struct BoundingBox {
 	NGP_HOST_DEVICE BoundingBox() {}
 
-	NGP_HOST_DEVICE BoundingBox(const Eigen::Vector3f& a, const Eigen::Vector3f& b) : min{a}, max{b} {}
+	NGP_HOST_DEVICE BoundingBox(const vec3& a, const vec3& b) : min{a}, max{b} {}
 
 	NGP_HOST_DEVICE explicit BoundingBox(const Triangle& tri) {
 		min = max = tri.a;
@@ -59,8 +59,8 @@ struct BoundingBox {
 	}
 
 	NGP_HOST_DEVICE void enlarge(const BoundingBox& other) {
-		min = min.cwiseMin(other.min);
-		max = max.cwiseMax(other.max);
+		min = glm::min(min, other.min);
+		max = glm::max(max, other.max);
 	}
 
 	NGP_HOST_DEVICE void enlarge(const Triangle& tri) {
@@ -69,32 +69,32 @@ struct BoundingBox {
 		enlarge(tri.c);
 	}
 
-	NGP_HOST_DEVICE void enlarge(const Eigen::Vector3f& point) {
-		min = min.cwiseMin(point);
-		max = max.cwiseMax(point);
+	NGP_HOST_DEVICE void enlarge(const vec3& point) {
+		min = glm::min(min, point);
+		max = glm::max(max, point);
 	}
 
 	NGP_HOST_DEVICE void inflate(float amount) {
-		min -= Eigen::Vector3f::Constant(amount);
-		max += Eigen::Vector3f::Constant(amount);
+		min -= vec3(amount);
+		max += vec3(amount);
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f diag() const {
+	NGP_HOST_DEVICE vec3 diag() const {
 		return max - min;
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f relative_pos(const Eigen::Vector3f& pos) const {
-		return (pos - min).cwiseQuotient(diag());
+	NGP_HOST_DEVICE vec3 relative_pos(const vec3& pos) const {
+		return (pos - min) / diag();
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f center() const {
+	NGP_HOST_DEVICE vec3 center() const {
 		return 0.5f * (max + min);
 	}
 
 	NGP_HOST_DEVICE BoundingBox intersection(const BoundingBox& other) const {
 		BoundingBox result = *this;
-		result.min = result.min.cwiseMax(other.min);
-		result.max = result.max.cwiseMin(other.max);
+		result.min = glm::max(result.min, other.min);
+		result.max = glm::min(result.max, other.max);
 		return result;
 	}
 
@@ -111,14 +111,14 @@ struct BoundingBox {
 		float box_min, box_max;
 
 		// Test the box normals (x-, y- and z-axes)
-		Eigen::Vector3f box_normals[3] = {
-			Eigen::Vector3f{1.0f, 0.0f, 0.0f},
-			Eigen::Vector3f{0.0f, 1.0f, 0.0f},
-			Eigen::Vector3f{0.0f, 0.0f, 1.0f},
+		vec3 box_normals[3] = {
+			vec3{1.0f, 0.0f, 0.0f},
+			vec3{0.0f, 1.0f, 0.0f},
+			vec3{0.0f, 0.0f, 1.0f},
 		};
 
-		Eigen::Vector3f triangle_normal = triangle.normal();
-		Eigen::Vector3f triangle_verts[3];
+		vec3 triangle_normal = triangle.normal();
+		vec3 triangle_verts[3];
 		triangle.get_vertices(triangle_verts);
 
 		for (int i = 0; i < 3; i++) {
@@ -128,18 +128,18 @@ struct BoundingBox {
 			}
 		}
 
-		Eigen::Vector3f verts[8];
+		vec3 verts[8];
 		get_vertices(verts);
 
 		// Test the triangle normal
-		float triangle_offset = triangle_normal.dot(triangle.a);
+		float triangle_offset = dot(triangle_normal, triangle.a);
 		project<8>(verts, triangle_normal, box_min, box_max);
 		if (box_max < triangle_offset || box_min > triangle_offset) {
 			return false; // No intersection possible.
 		}
 
 		// Test the nine edge cross-products
-		Eigen::Vector3f edges[3] = {
+		vec3 edges[3] = {
 			triangle.a - triangle.b,
 			triangle.a - triangle.c,
 			triangle.b - triangle.c,
@@ -148,7 +148,7 @@ struct BoundingBox {
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 3; j++) {
 				// The box normals are the same as it's edge tangents
-				Eigen::Vector3f axis = edges[i].cross(box_normals[j]);
+				vec3 axis = cross(edges[i], box_normals[j]);
 				project<8>(verts, axis, box_min, box_max);
 				project<3>(triangle_verts, axis, triangle_min, triangle_max);
 				if (box_max < triangle_min || box_min > triangle_max)
@@ -160,16 +160,16 @@ struct BoundingBox {
 		return true;
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector2f ray_intersect(const Eigen::Vector3f& pos, const Eigen::Vector3f& dir) const {
-		float tmin = (min.x() - pos.x()) / dir.x();
-		float tmax = (max.x() - pos.x()) / dir.x();
+	NGP_HOST_DEVICE vec2 ray_intersect(const vec3& pos, const vec3& dir) const {
+		float tmin = (min.x - pos.x) / dir.x;
+		float tmax = (max.x - pos.x) / dir.x;
 
 		if (tmin > tmax) {
 			tcnn::host_device_swap(tmin, tmax);
 		}
 
-		float tymin = (min.y() - pos.y()) / dir.y();
-		float tymax = (max.y() - pos.y()) / dir.y();
+		float tymin = (min.y - pos.y) / dir.y;
+		float tymax = (max.y - pos.y) / dir.y;
 
 		if (tymin > tymax) {
 			tcnn::host_device_swap(tymin, tymax);
@@ -187,8 +187,8 @@ struct BoundingBox {
 			tmax = tymax;
 		}
 
-		float tzmin = (min.z() - pos.z()) / dir.z();
-		float tzmax = (max.z() - pos.z()) / dir.z();
+		float tzmin = (min.z - pos.z) / dir.z;
+		float tzmax = (max.z - pos.z) / dir.z;
 
 		if (tzmin > tzmax) {
 			tcnn::host_device_swap(tzmin, tzmax);
@@ -210,49 +210,49 @@ struct BoundingBox {
 	}
 
 	NGP_HOST_DEVICE bool is_empty() const {
-		return (max.array() < min.array()).any();
+		return any(lessThan(max, min));
 	}
 
-	NGP_HOST_DEVICE bool contains(const Eigen::Vector3f& p) const {
+	NGP_HOST_DEVICE bool contains(const vec3& p) const {
 		return
-			p.x() >= min.x() && p.x() <= max.x() &&
-			p.y() >= min.y() && p.y() <= max.y() &&
-			p.z() >= min.z() && p.z() <= max.z();
+			p.x >= min.x && p.x <= max.x &&
+			p.y >= min.y && p.y <= max.y &&
+			p.z >= min.z && p.z <= max.z;
 	}
 
 	/// Calculate the squared point-AABB distance
-	NGP_HOST_DEVICE float distance(const Eigen::Vector3f& p) const {
+	NGP_HOST_DEVICE float distance(const vec3& p) const {
 		return sqrt(distance_sq(p));
 	}
 
-	NGP_HOST_DEVICE float distance_sq(const Eigen::Vector3f& p) const {
-		return (min - p).cwiseMax(p - max).cwiseMax(0.0f).squaredNorm();
+	NGP_HOST_DEVICE float distance_sq(const vec3& p) const {
+		return length2(glm::max(glm::max(min - p, p - max), vec3(0.0f)));
 	}
 
-	NGP_HOST_DEVICE float signed_distance(const Eigen::Vector3f& p) const {
-		Eigen::Vector3f q = (p - min).cwiseAbs() - diag();
-		return q.cwiseMax(0.0f).norm() + std::min(std::max(q.x(), std::max(q.y(), q.z())), 0.0f);
+	NGP_HOST_DEVICE float signed_distance(const vec3& p) const {
+		vec3 q = abs(p - min) - diag();
+		return length(glm::max(q, vec3(0.0f))) + std::min(compMax(q), 0.0f);
 	}
 
-	NGP_HOST_DEVICE void get_vertices(Eigen::Vector3f v[8]) const {
-		v[0] = {min.x(), min.y(), min.z()};
-		v[1] = {min.x(), min.y(), max.z()};
-		v[2] = {min.x(), max.y(), min.z()};
-		v[3] = {min.x(), max.y(), max.z()};
-		v[4] = {max.x(), min.y(), min.z()};
-		v[5] = {max.x(), min.y(), max.z()};
-		v[6] = {max.x(), max.y(), min.z()};
-		v[7] = {max.x(), max.y(), max.z()};
+	NGP_HOST_DEVICE void get_vertices(vec3 v[8]) const {
+		v[0] = {min.x, min.y, min.z};
+		v[1] = {min.x, min.y, max.z};
+		v[2] = {min.x, max.y, min.z};
+		v[3] = {min.x, max.y, max.z};
+		v[4] = {max.x, min.y, min.z};
+		v[5] = {max.x, min.y, max.z};
+		v[6] = {max.x, max.y, min.z};
+		v[7] = {max.x, max.y, max.z};
 	}
 
-	Eigen::Vector3f min = Eigen::Vector3f::Constant(std::numeric_limits<float>::infinity());
-	Eigen::Vector3f max = Eigen::Vector3f::Constant(-std::numeric_limits<float>::infinity());
+	vec3 min = vec3(std::numeric_limits<float>::infinity());
+	vec3 max = vec3(-std::numeric_limits<float>::infinity());
 };
 
 inline std::ostream& operator<<(std::ostream& os, const ngp::BoundingBox& bb) {
 	os << "[";
-	os << "min=[" << bb.min.x() << "," << bb.min.y() << "," << bb.min.z() << "], ";
-	os << "max=[" << bb.max.x() << "," << bb.max.y() << "," << bb.max.z() << "]";
+	os << "min=[" << bb.min.x << "," << bb.min.y << "," << bb.min.z << "], ";
+	os << "max=[" << bb.max.x << "," << bb.max.y << "," << bb.max.z << "]";
 	os << "]";
 	return os;
 }

--- a/include/neural-graphics-primitives/camera_path.h
+++ b/include/neural-graphics-primitives/camera_path.h
@@ -18,8 +18,10 @@
 
 #include <tiny-cuda-nn/common.h>
 
+#ifdef NGP_GUI
 #include <imgui/imgui.h>
 #include <imguizmo/ImGuizmo.h>
+#endif
 
 #include <chrono>
 #include <vector>

--- a/include/neural-graphics-primitives/dlss.h
+++ b/include/neural-graphics-primitives/dlss.h
@@ -16,8 +16,6 @@
 
 #include <neural-graphics-primitives/common.h>
 
-#include <Eigen/Dense>
-
 #include <memory>
 
 NGP_NAMESPACE_BEGIN
@@ -27,15 +25,15 @@ public:
 	virtual ~IDlss() {}
 
 	virtual void update_feature(
-		const Eigen::Vector2i& in_resolution,
+		const ivec2& in_resolution,
 		bool is_hdr,
 		bool sharpen
 	) = 0;
 	virtual void run(
-		const Eigen::Vector2i& in_resolution,
+		const ivec2& in_resolution,
 		bool is_hdr,
 		float sharpening,
-		const Eigen::Vector2f& jitter_offset,
+		const vec2& jitter_offset,
 		bool shall_reset
 	) = 0;
 
@@ -45,9 +43,9 @@ public:
 	virtual cudaSurfaceObject_t exposure() = 0;
 	virtual cudaSurfaceObject_t output() = 0;
 
-	virtual Eigen::Vector2i clamp_resolution(const Eigen::Vector2i& resolution) const = 0;
-	virtual Eigen::Vector2i out_resolution() const = 0;
-	virtual Eigen::Vector2i max_out_resolution() const = 0;
+	virtual ivec2 clamp_resolution(const ivec2& resolution) const = 0;
+	virtual ivec2 out_resolution() const = 0;
+	virtual ivec2 max_out_resolution() const = 0;
 
 	virtual bool is_hdr() const = 0;
 	virtual bool sharpen() const = 0;
@@ -59,7 +57,7 @@ public:
 	virtual ~IDlssProvider() {}
 
 	virtual size_t allocated_bytes() const = 0;
-	virtual std::unique_ptr<IDlss> init_dlss(const Eigen::Vector2i& out_resolution) = 0;
+	virtual std::unique_ptr<IDlss> init_dlss(const ivec2& out_resolution) = 0;
 };
 
 #ifdef NGP_VULKAN

--- a/include/neural-graphics-primitives/envmap.cuh
+++ b/include/neural-graphics-primitives/envmap.cuh
@@ -26,71 +26,71 @@
 
 NGP_NAMESPACE_BEGIN
 
-inline __device__ Eigen::Array4f read_envmap(const Buffer2DView<const Eigen::Array4f>& envmap, const Eigen::Vector3f& dir) {
-	auto dir_cyl = dir_to_spherical_unorm({dir.z(), -dir.x(), dir.y()});
+inline __device__ vec4 read_envmap(const Buffer2DView<const vec4>& envmap, const vec3& dir) {
+	auto dir_cyl = dir_to_spherical_unorm({dir.z, -dir.x, dir.y});
 
-	auto envmap_float = Eigen::Vector2f{dir_cyl.y() * (envmap.resolution.x()-1), dir_cyl.x() * (envmap.resolution.y()-1)};
-	Eigen::Vector2i envmap_texel = envmap_float.cast<int>();
+	auto envmap_float = vec2{dir_cyl.y * (envmap.resolution.x-1), dir_cyl.x * (envmap.resolution.y-1)};
+	ivec2 envmap_texel = envmap_float;
 
-	auto weight = envmap_float - envmap_texel.cast<float>();
+	auto weight = envmap_float - vec2(envmap_texel);
 
-	auto read_val = [&](Eigen::Vector2i pos) {
-		if (pos.x() < 0) {
-			pos.x() += envmap.resolution.x();
-		} else if (pos.x() >= envmap.resolution.x()) {
-			pos.x() -= envmap.resolution.x();
+	auto read_val = [&](ivec2 pos) {
+		if (pos.x < 0) {
+			pos.x += envmap.resolution.x;
+		} else if (pos.x >= envmap.resolution.x) {
+			pos.x -= envmap.resolution.x;
 		}
-		pos.y() = std::max(std::min(pos.y(), envmap.resolution.y()-1), 0);
+		pos.y = std::max(std::min(pos.y, envmap.resolution.y-1), 0);
 		return envmap.at(pos);
 	};
 
 	auto result = (
-		(1 - weight.x()) * (1 - weight.y()) * read_val({envmap_texel.x(), envmap_texel.y()}) +
-		(weight.x()) * (1 - weight.y()) * read_val({envmap_texel.x()+1, envmap_texel.y()}) +
-		(1 - weight.x()) * (weight.y()) * read_val({envmap_texel.x(), envmap_texel.y()+1}) +
-		(weight.x()) * (weight.y()) * read_val({envmap_texel.x()+1, envmap_texel.y()+1})
+		(1 - weight.x) * (1 - weight.y) * read_val({envmap_texel.x, envmap_texel.y}) +
+		(weight.x) * (1 - weight.y) * read_val({envmap_texel.x+1, envmap_texel.y}) +
+		(1 - weight.x) * (weight.y) * read_val({envmap_texel.x, envmap_texel.y+1}) +
+		(weight.x) * (weight.y) * read_val({envmap_texel.x+1, envmap_texel.y+1})
 	);
 
 	return result;
 }
 
 template <typename T, typename GRAD_T>
-__device__ void deposit_envmap_gradient(const tcnn::vector_t<T, 4>& value, GRAD_T* __restrict__ envmap_gradient, const Eigen::Vector2i envmap_resolution, const Eigen::Vector3f& dir) {
-	auto dir_cyl = dir_to_spherical_unorm({dir.z(), -dir.x(), dir.y()});
+__device__ void deposit_envmap_gradient(const tcnn::vector_t<T, 4>& value, GRAD_T* __restrict__ envmap_gradient, const ivec2 envmap_resolution, const vec3& dir) {
+	auto dir_cyl = dir_to_spherical_unorm({dir.z, -dir.x, dir.y});
 
-	auto envmap_float = Eigen::Vector2f{dir_cyl.y() * (envmap_resolution.x()-1), dir_cyl.x() * (envmap_resolution.y()-1)};
-	Eigen::Vector2i envmap_texel = envmap_float.cast<int>();
+	auto envmap_float = vec2{dir_cyl.y * (envmap_resolution.x-1), dir_cyl.x * (envmap_resolution.y-1)};
+	ivec2 envmap_texel = envmap_float;
 
-	auto weight = envmap_float - envmap_texel.cast<float>();
+	auto weight = envmap_float - vec2(envmap_texel);
 
-	auto deposit_val = [&](const tcnn::vector_t<T, 4>& value, T weight, Eigen::Vector2i pos) {
-		if (pos.x() < 0) {
-			pos.x() += envmap_resolution.x();
-		} else if (pos.x() >= envmap_resolution.x()) {
-			pos.x() -= envmap_resolution.x();
+	auto deposit_val = [&](const tcnn::vector_t<T, 4>& value, T weight, ivec2 pos) {
+		if (pos.x < 0) {
+			pos.x += envmap_resolution.x;
+		} else if (pos.x >= envmap_resolution.x) {
+			pos.x -= envmap_resolution.x;
 		}
-		pos.y() = std::max(std::min(pos.y(), envmap_resolution.y()-1), 0);
+		pos.y = std::max(std::min(pos.y, envmap_resolution.y-1), 0);
 
-		Eigen::Array4f result;
+		vec4 result;
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600 // atomicAdd(__half2) is only supported with compute capability 60 and above
 		if (std::is_same<GRAD_T, __half>::value) {
 			for (uint32_t c = 0; c < 4; c += 2) {
-				atomicAdd((__half2*)&envmap_gradient[(pos.x() + pos.y() * envmap_resolution.x()) * 4 + c], {value[c] * weight, value[c+1] * weight});
+				atomicAdd((__half2*)&envmap_gradient[(pos.x + pos.y * envmap_resolution.x) * 4 + c], {value[c] * weight, value[c+1] * weight});
 			}
 		} else
 #endif
 		{
 			for (uint32_t c = 0; c < 4; ++c) {
-				atomicAdd(&envmap_gradient[(pos.x() + pos.y() * envmap_resolution.x()) * 4 + c], (GRAD_T)(value[c] * weight));
+				atomicAdd(&envmap_gradient[(pos.x + pos.y * envmap_resolution.x) * 4 + c], (GRAD_T)(value[c] * weight));
 			}
 		}
 	};
 
-	deposit_val(value, (1 - weight.x()) * (1 - weight.y()), {envmap_texel.x(), envmap_texel.y()});
-	deposit_val(value, (weight.x()) * (1 - weight.y()), {envmap_texel.x()+1, envmap_texel.y()});
-	deposit_val(value, (1 - weight.x()) * (weight.y()), {envmap_texel.x(), envmap_texel.y()+1});
-	deposit_val(value, (weight.x()) * (weight.y()), {envmap_texel.x()+1, envmap_texel.y()+1});
+	deposit_val(value, (1 - weight.x) * (1 - weight.y), {envmap_texel.x, envmap_texel.y});
+	deposit_val(value, (weight.x) * (1 - weight.y), {envmap_texel.x+1, envmap_texel.y});
+	deposit_val(value, (1 - weight.x) * (weight.y), {envmap_texel.x, envmap_texel.y+1});
+	deposit_val(value, (weight.x) * (weight.y), {envmap_texel.x+1, envmap_texel.y+1});
 }
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -20,94 +20,143 @@
 
 #include <json/json.hpp>
 
+// Conversion between glm and json
+namespace glm {
+	template <typename T>
+	void to_json(nlohmann::json& j, const tmat3x3<T>& mat) {
+		for (int row = 0; row < 3; ++row) {
+			nlohmann::json column = nlohmann::json::array();
+			for (int col = 0; col < 3; ++col) {
+				column.push_back(mat[col][row]);
+			}
+			j.push_back(column);
+		}
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tmat3x3<T>& mat) {
+		for (std::size_t row = 0; row < 3; ++row) {
+			const auto& jrow = j.at(row);
+			for (std::size_t col = 0; col < 3; ++col) {
+				const auto& value = jrow.at(col);
+				mat[col][row] = value.get<T>();
+			}
+		}
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tmat4x3<T>& mat) {
+		for (int row = 0; row < 3; ++row) {
+			nlohmann::json column = nlohmann::json::array();
+			for (int col = 0; col < 4; ++col) {
+				column.push_back(mat[col][row]);
+			}
+			j.push_back(column);
+		}
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tmat4x3<T>& mat) {
+		for (std::size_t row = 0; row < 3; ++row) {
+			const auto& jrow = j.at(row);
+			for (std::size_t col = 0; col < 4; ++col) {
+				const auto& value = jrow.at(col);
+				mat[col][row] = value.get<T>();
+			}
+		}
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tmat4x4<T>& mat) {
+		for (int row = 0; row < 4; ++row) {
+			nlohmann::json column = nlohmann::json::array();
+			for (int col = 0; col < 4; ++col) {
+				column.push_back(mat[col][row]);
+			}
+			j.push_back(column);
+		}
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tmat4x4<T>& mat) {
+		for (std::size_t row = 0; row < 4; ++row) {
+			const auto& jrow = j.at(row);
+			for (std::size_t col = 0; col < 4; ++col) {
+				const auto& value = jrow.at(col);
+				mat[col][row] = value.get<T>();
+			}
+		}
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tvec2<T>& v) {
+		j.push_back(v.x);
+		j.push_back(v.y);
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tvec2<T>& v) {
+		v.x = j.at(0).get<T>();
+		v.y = j.at(1).get<T>();
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tvec3<T>& v) {
+		j.push_back(v.x);
+		j.push_back(v.y);
+		j.push_back(v.z);
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tvec3<T>& v) {
+		v.x = j.at(0).get<T>();
+		v.y = j.at(1).get<T>();
+		v.z = j.at(2).get<T>();
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tvec4<T>& v) {
+		j.push_back(v.x);
+		j.push_back(v.y);
+		j.push_back(v.z);
+		j.push_back(v.w);
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tvec4<T>& v) {
+		v.x = j.at(0).get<T>();
+		v.y = j.at(1).get<T>();
+		v.z = j.at(2).get<T>();
+		v.w = j.at(3).get<T>();
+	}
+
+	template <typename T>
+	void to_json(nlohmann::json& j, const tquat<T>& q) {
+		j.push_back(q.w);
+		j.push_back(q.x);
+		j.push_back(q.y);
+		j.push_back(q.z);
+	}
+
+	template <typename T>
+	void from_json(const nlohmann::json& j, tquat<T>& q) {
+		q.w = j.at(0).get<T>();
+		q.x = j.at(1).get<T>();
+		q.y = j.at(2).get<T>();
+		q.z = j.at(3).get<T>();
+	}
+}
+
 NGP_NAMESPACE_BEGIN
 
-// Conversion between eigen and json
-template <typename Derived>
-void to_json(nlohmann::json& j, const Eigen::MatrixBase<Derived>& mat) {
-	for (int row = 0; row < mat.rows(); ++row) {
-		if (mat.cols() == 1) {
-			j.push_back(mat(row));
-		} else {
-			nlohmann::json column = nlohmann::json::array();
-			for (int col = 0; col < mat.cols(); ++col) {
-				column.push_back(mat(row, col));
-			}
-			j.push_back(column);
-		}
-	}
-}
-
-template <typename Derived>
-void from_json(const nlohmann::json& j, Eigen::MatrixBase<Derived>& mat) {
-	for (std::size_t row = 0; row < j.size(); ++row) {
-		const auto& jrow = j.at(row);
-		if (jrow.is_array()) {
-			for (std::size_t col = 0; col < jrow.size(); ++col) {
-				const auto& value = jrow.at(col);
-				mat(row, col) = value.get<typename Eigen::MatrixBase<Derived>::Scalar>();
-			}
-		} else {
-			mat(row) = jrow.get<typename Eigen::MatrixBase<Derived>::Scalar>();
-		}
-	}
-}
-
-template <typename Derived>
-void to_json(nlohmann::json& j, const Eigen::ArrayBase<Derived>& mat) {
-	for (int row = 0; row < mat.rows(); ++row) {
-		if (mat.cols() == 1) {
-			j.push_back(mat(row));
-		} else {
-			nlohmann::json column = nlohmann::json::array();
-			for (int col = 0; col < mat.cols(); ++col) {
-				column.push_back(mat(row, col));
-			}
-			j.push_back(column);
-		}
-	}
-}
-
-template <typename Derived>
-void from_json(const nlohmann::json& j, Eigen::ArrayBase<Derived>& mat) {
-	for (std::size_t row = 0; row < j.size(); ++row) {
-		const auto& jrow = j.at(row);
-		if (jrow.is_array()) {
-			for (std::size_t col = 0; col < jrow.size(); ++col) {
-				const auto& value = jrow.at(col);
-				mat(row, col) = value.get<typename Eigen::ArrayBase<Derived>::Scalar>();
-			}
-		} else {
-			mat(row) = jrow.get<typename Eigen::ArrayBase<Derived>::Scalar>();
-		}
-	}
-}
-
-template <typename Derived>
-void to_json(nlohmann::json& j, const Eigen::QuaternionBase<Derived>& q) {
-	j.push_back(q.w());
-	j.push_back(q.x());
-	j.push_back(q.y());
-	j.push_back(q.z());
-}
-
-template <typename Derived>
-void from_json(const nlohmann::json& j, Eigen::QuaternionBase<Derived>& q) {
-	using Scalar = typename Eigen::QuaternionBase<Derived>::Scalar;
-	q.w() = j.at(0).get<Scalar>();
-	q.x() = j.at(1).get<Scalar>();
-	q.y() = j.at(2).get<Scalar>();
-	q.z() = j.at(3).get<Scalar>();
-}
-
 inline void to_json(nlohmann::json& j, const BoundingBox& box) {
-	to_json(j["min"], box.min);
-	to_json(j["max"], box.max);
+	j["min"] = box.min;
+	j["max"] = box.max;
 }
 
 inline void from_json(const nlohmann::json& j, BoundingBox& box) {
-	from_json(j.at("min"), box.min);
-	from_json(j.at("max"), box.max);
+	box.min = j.at("min");
+	box.max = j.at("max");
 }
 
 inline void to_json(nlohmann::json& j, const Lens& lens) {
@@ -164,13 +213,13 @@ inline void from_json(const nlohmann::json& j, Lens& lens) {
 }
 
 inline void from_json(const nlohmann::json& j, TrainingXForm& x) {
-	from_json(j.at("start"), x.start);
-	from_json(j.at("end"), x.end);
+	x.start = j.at("start");
+	x.end = j.at("end");
 }
 
 inline void to_json(nlohmann::json& j, const TrainingXForm& x) {
-	to_json(j["start"], x.start);
-	to_json(j["end"], x.end);
+	j["start"] = x.start;
+	j["end"] = x.end;
 }
 
 inline void to_json(nlohmann::json& j, const NerfDataset& dataset) {
@@ -179,18 +228,18 @@ inline void to_json(nlohmann::json& j, const NerfDataset& dataset) {
 	for (size_t i = 0; i < dataset.n_images; ++i) {
 		j["metadata"].emplace_back();
 		j["xforms"].emplace_back();
-		to_json(j["metadata"].at(i)["focal_length"], dataset.metadata[i].focal_length);
-		to_json(j["metadata"].at(i)["lens"], dataset.metadata[i].lens);
-		to_json(j["metadata"].at(i)["principal_point"], dataset.metadata[i].principal_point);
-		to_json(j["metadata"].at(i)["rolling_shutter"], dataset.metadata[i].rolling_shutter);
-		to_json(j["metadata"].at(i)["resolution"], dataset.metadata[i].resolution);
-		to_json(j["xforms"].at(i), dataset.xforms[i]);
+		j["metadata"].at(i)["focal_length"] = dataset.metadata[i].focal_length;
+		j["metadata"].at(i)["lens"] = dataset.metadata[i].lens;
+		j["metadata"].at(i)["principal_point"] = dataset.metadata[i].principal_point;
+		j["metadata"].at(i)["rolling_shutter"] = dataset.metadata[i].rolling_shutter;
+		j["metadata"].at(i)["resolution"] = dataset.metadata[i].resolution;
+		j["xforms"].at(i) = dataset.xforms[i];
 	}
 	j["render_aabb"] = dataset.render_aabb;
-	to_json(j["render_aabb_to_local"], dataset.render_aabb_to_local);
-	to_json(j["up"], dataset.up);
-	to_json(j["offset"], dataset.offset);
-	to_json(j["envmap_resolution"], dataset.envmap_resolution);
+	j["render_aabb_to_local"] = dataset.render_aabb_to_local;
+	j["up"] = dataset.up;
+	j["offset"] = dataset.offset;
+	j["envmap_resolution"] = dataset.envmap_resolution;
 	j["scale"] = dataset.scale;
 	j["aabb_scale"] = dataset.aabb_scale;
 	j["from_mitsuba"] = dataset.from_mitsuba;
@@ -208,34 +257,34 @@ inline void from_json(const nlohmann::json& j, NerfDataset& dataset) {
 
 	for (size_t i = 0; i < dataset.n_images; ++i) {
 		// read global defaults first
-		if (j.contains("lens")) from_json(j.at("lens"), dataset.metadata[i].lens);
+		if (j.contains("lens")) dataset.metadata[i].lens = j.at("lens");
 		// Legacy: "lens" used to be called "camera_distortion"
-		if (j.contains("camera_distortion")) from_json(j.at("camera_distortion"), dataset.metadata[i].lens);
-		if (j.contains("principal_point")) from_json(j.at("principal_point"), dataset.metadata[i].principal_point);
-		if (j.contains("rolling_shutter")) from_json(j.at("rolling_shutter"), dataset.metadata[i].rolling_shutter);
-		if (j.contains("focal_length")) from_json(j.at("focal_length"), dataset.metadata[i].focal_length);
-		if (j.contains("image_resolution")) from_json(j.at("image_resolution"), dataset.metadata[i].resolution);
+		if (j.contains("camera_distortion")) dataset.metadata[i].lens = j.at("camera_distortion");
+		if (j.contains("principal_point")) dataset.metadata[i].principal_point = j.at("principal_point");
+		if (j.contains("rolling_shutter")) dataset.metadata[i].rolling_shutter = j.at("rolling_shutter");
+		if (j.contains("focal_length")) dataset.metadata[i].focal_length = j.at("focal_length");
+		if (j.contains("image_resolution")) dataset.metadata[i].resolution = j.at("image_resolution");
 
-		from_json(j.at("xforms").at(i), dataset.xforms[i]);
-		if (j.contains("focal_lengths")) from_json(j.at("focal_lengths").at(i), dataset.metadata[i].focal_length);
+		dataset.xforms[i] = j.at("xforms").at(i);
+		if (j.contains("focal_lengths")) dataset.metadata[i].focal_length = j.at("focal_lengths").at(i);
 		if (j.contains("metadata")) {
 			auto &ji = j["metadata"].at(i);
-			from_json(ji.at("resolution"), dataset.metadata[i].resolution);
-			from_json(ji.at("focal_length"), dataset.metadata[i].focal_length);
-			from_json(ji.at("principal_point"), dataset.metadata[i].principal_point);
-			if (ji.contains("lens")) from_json(ji.at("lens"), dataset.metadata[i].lens);
+			dataset.metadata[i].resolution = ji.at("resolution");
+			dataset.metadata[i].focal_length = ji.at("focal_length");
+			dataset.metadata[i].principal_point = ji.at("principal_point");
+			if (ji.contains("lens")) dataset.metadata[i].lens = ji.at("lens");
 			// Legacy: "lens" used to be called "camera_distortion"
-			if (ji.contains("camera_distortion")) from_json(ji.at("camera_distortion"), dataset.metadata[i].lens);
+			if (ji.contains("camera_distortion")) dataset.metadata[i].lens = ji.at("camera_distortion");
 		}
 	}
 
 	dataset.render_aabb = j.at("render_aabb");
-	dataset.render_aabb_to_local = Eigen::Matrix3f::Identity();
-	if (j.contains("render_aabb_to_local")) from_json(j.at("render_aabb_to_local"), dataset.render_aabb_to_local);
+	dataset.render_aabb_to_local = mat3(1.0f);
+	if (j.contains("render_aabb_to_local")) dataset.render_aabb_to_local = j.at("render_aabb_to_local");
 
-	from_json(j.at("up"), dataset.up);
-	from_json(j.at("offset"), dataset.offset);
-	from_json(j.at("envmap_resolution"), dataset.envmap_resolution);
+	dataset.up = j.at("up");
+	dataset.offset = j.at("offset");
+	dataset.envmap_resolution = j.at("envmap_resolution");
 	dataset.scale = j.at("scale");
 	dataset.aabb_scale = j.at("aabb_scale");
 	dataset.from_mitsuba = j.at("from_mitsuba");

--- a/include/neural-graphics-primitives/marching_cubes.h
+++ b/include/neural-graphics-primitives/marching_cubes.h
@@ -20,48 +20,48 @@
 
 NGP_NAMESPACE_BEGIN
 
-Eigen::Vector3i get_marching_cubes_res(uint32_t res_1d, const BoundingBox& render_aabb);
+ivec3 get_marching_cubes_res(uint32_t res_1d, const BoundingBox& render_aabb);
 
-void marching_cubes_gpu(cudaStream_t stream, BoundingBox render_aabb, Eigen::Matrix3f render_aabb_to_local, Eigen::Vector3i res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<Eigen::Vector3f>& vert_out, tcnn::GPUMemory<uint32_t>& indices_out);
+void marching_cubes_gpu(cudaStream_t stream, BoundingBox render_aabb, mat3 render_aabb_to_local, ivec3 res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<vec3>& vert_out, tcnn::GPUMemory<uint32_t>& indices_out);
 
 // computes the average of the 1ring of all verts, as homogenous coordinates
-void compute_mesh_1ring(const tcnn::GPUMemory<Eigen::Vector3f>& verts, const tcnn::GPUMemory<uint32_t>& indices, tcnn::GPUMemory<Eigen::Vector4f>& output_pos, tcnn::GPUMemory<Eigen::Vector3f>& output_normals);
+void compute_mesh_1ring(const tcnn::GPUMemory<vec3>& verts, const tcnn::GPUMemory<uint32_t>& indices, tcnn::GPUMemory<vec4>& output_pos, tcnn::GPUMemory<vec3>& output_normals);
 
 void compute_mesh_opt_gradients(
 	float thresh,
-	const tcnn::GPUMemory<Eigen::Vector3f>& verts,
-	const tcnn::GPUMemory<Eigen::Vector3f>& vert_normals,
-	const tcnn::GPUMemory<Eigen::Vector4f>& verts_smoothed,
+	const tcnn::GPUMemory<vec3>& verts,
+	const tcnn::GPUMemory<vec3>& vert_normals,
+	const tcnn::GPUMemory<vec4>& verts_smoothed,
 	const tcnn::network_precision_t* densities,
 	uint32_t input_gradient_width,
 	const float* input_gradients,
-	tcnn::GPUMemory<Eigen::Vector3f>& verts_gradient_out,
+	tcnn::GPUMemory<vec3>& verts_gradient_out,
 	float k_smooth_amount,
 	float k_density_amount,
 	float k_inflate_amount
 );
 
 void save_mesh(
-	tcnn::GPUMemory<Eigen::Vector3f>& verts,
-	tcnn::GPUMemory<Eigen::Vector3f>& normals,
-	tcnn::GPUMemory<Eigen::Vector3f>& colors,
+	tcnn::GPUMemory<vec3>& verts,
+	tcnn::GPUMemory<vec3>& normals,
+	tcnn::GPUMemory<vec3>& colors,
 	tcnn::GPUMemory<uint32_t>& indices,
 	const fs::path& path,
 	bool unwrap_it,
 	float nerf_scale,
-	Eigen::Vector3f nerf_offset
+	vec3 nerf_offset
 );
 
 #ifdef NGP_GUI
 void draw_mesh_gl(
-	const tcnn::GPUMemory<Eigen::Vector3f>& verts,
-	const tcnn::GPUMemory<Eigen::Vector3f>& normals,
-	const tcnn::GPUMemory<Eigen::Vector3f>& cols,
+	const tcnn::GPUMemory<vec3>& verts,
+	const tcnn::GPUMemory<vec3>& normals,
+	const tcnn::GPUMemory<vec3>& cols,
 	const tcnn::GPUMemory<uint32_t>& indices,
-	const Eigen::Vector2i& resolution,
-	const Eigen::Vector2f& focal_length,
-	const Eigen::Matrix<float, 3, 4>& camera_matrix,
-	const Eigen::Vector2f& screen_center,
+	const ivec2& resolution,
+	const vec2& focal_length,
+	const mat4x3& camera_matrix,
+	const vec2& screen_center,
 	int mesh_render_mode
 );
 
@@ -70,10 +70,10 @@ uint32_t compile_shader(bool pixel, const char* code);
 bool check_shader(uint32_t handle, const char* desc, bool program);
 #endif
 
-void save_density_grid_to_png(const tcnn::GPUMemory<float>& density, const fs::path& path, Eigen::Vector3i res3d, float thresh, bool swap_y_z = true, float density_range = 4.f);
+void save_density_grid_to_png(const tcnn::GPUMemory<float>& density, const fs::path& path, ivec3 res3d, float thresh, bool swap_y_z = true, float density_range = 4.f);
 
-void save_rgba_grid_to_png_sequence(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const fs::path& path, Eigen::Vector3i res3d, bool swap_y_z = true);
+void save_rgba_grid_to_png_sequence(const tcnn::GPUMemory<vec4>& rgba, const fs::path& path, ivec3 res3d, bool swap_y_z = true);
 
-void save_rgba_grid_to_raw_file(const tcnn::GPUMemory<Eigen::Array4f>& rgba, const fs::path& path, Eigen::Vector3i res3d, bool swap_y_z, int cascade);
+void save_rgba_grid_to_raw_file(const tcnn::GPUMemory<vec4>& rgba, const fs::path& path, ivec3 res3d, bool swap_y_z, int cascade);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/nerf.h
+++ b/include/neural-graphics-primitives/nerf.h
@@ -30,8 +30,8 @@ inline constexpr __device__ uint32_t NERF_GRID_N_CELLS() {
 }
 
 struct NerfPayload {
-	Eigen::Vector3f origin;
-	Eigen::Vector3f dir;
+	vec3 origin;
+	vec3 dir;
 	float t;
 	float max_weight;
 	uint32_t idx;
@@ -42,20 +42,20 @@ struct NerfPayload {
 struct RaysNerfSoa {
 #if defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))
 	void copy_from_other_async(const RaysNerfSoa& other, cudaStream_t stream) {
-		CUDA_CHECK_THROW(cudaMemcpyAsync(rgba, other.rgba, size * sizeof(Eigen::Array4f), cudaMemcpyDeviceToDevice, stream));
+		CUDA_CHECK_THROW(cudaMemcpyAsync(rgba, other.rgba, size * sizeof(vec4), cudaMemcpyDeviceToDevice, stream));
 		CUDA_CHECK_THROW(cudaMemcpyAsync(depth, other.depth, size * sizeof(float), cudaMemcpyDeviceToDevice, stream));
 		CUDA_CHECK_THROW(cudaMemcpyAsync(payload, other.payload, size * sizeof(NerfPayload), cudaMemcpyDeviceToDevice, stream));
 	}
 #endif
 
-	void set(Eigen::Array4f* rgba, float* depth, NerfPayload* payload, size_t size) {
+	void set(vec4* rgba, float* depth, NerfPayload* payload, size_t size) {
 		this->rgba = rgba;
 		this->depth = depth;
 		this->payload = payload;
 		this->size = size;
 	}
 
-	Eigen::Array4f* rgba;
+	vec4* rgba;
 	float* depth;
 	NerfPayload* payload;
 	size_t size;
@@ -64,27 +64,27 @@ struct RaysNerfSoa {
 //#define TRIPLANAR_COMPATIBLE_POSITIONS   // if this is defined, then positions are stored as [x,y,z,x] so that it can be split as [x,y] [y,z] [z,x] by the input encoding
 
 struct NerfPosition {
-	NGP_HOST_DEVICE NerfPosition(const Eigen::Vector3f& pos, float dt)
+	NGP_HOST_DEVICE NerfPosition(const vec3& pos, float dt)
 	:
 	p{pos}
 #ifdef TRIPLANAR_COMPATIBLE_POSITIONS
-	, x{pos.x()}
+	, x{pos.x}
 #endif
 	{}
-	Eigen::Vector3f p;
+	vec3 p;
 #ifdef TRIPLANAR_COMPATIBLE_POSITIONS
 	float x;
 #endif
 };
 
 struct NerfDirection {
-	NGP_HOST_DEVICE NerfDirection(const Eigen::Vector3f& dir, float dt) : d{dir} {}
-	Eigen::Vector3f d;
+	NGP_HOST_DEVICE NerfDirection(const vec3& dir, float dt) : d{dir} {}
+	vec3 d;
 };
 
 struct NerfCoordinate {
-	NGP_HOST_DEVICE NerfCoordinate(const Eigen::Vector3f& pos, const Eigen::Vector3f& dir, float dt) : pos{pos, dt}, dt{dt}, dir{dir, dt} {}
-	NGP_HOST_DEVICE void set_with_optional_extra_dims(const Eigen::Vector3f& pos, const Eigen::Vector3f& dir, float dt, const float* extra_dims, uint32_t stride_in_bytes) {
+	NGP_HOST_DEVICE NerfCoordinate(const vec3& pos, const vec3& dir, float dt) : pos{pos, dt}, dt{dt}, dir{dir, dt} {}
+	NGP_HOST_DEVICE void set_with_optional_extra_dims(const vec3& pos, const vec3& dir, float dt, const float* extra_dims, uint32_t stride_in_bytes) {
 		this->dt = dt;
 		this->pos = NerfPosition(pos, dt);
 		this->dir = NerfDirection(dir, dt);

--- a/include/neural-graphics-primitives/nerf_loader.h
+++ b/include/neural-graphics-primitives/nerf_loader.h
@@ -37,11 +37,11 @@ struct TrainingImageMetadata {
 	const Ray* rays = nullptr;
 
 	Lens lens = {};
-	Eigen::Vector2i resolution = Eigen::Vector2i::Zero();
-	Eigen::Vector2f principal_point = Eigen::Vector2f::Constant(0.5f);
-	Eigen::Vector2f focal_length = Eigen::Vector2f::Constant(1000.f);
-	Eigen::Vector4f rolling_shutter = Eigen::Vector4f::Zero();
-	Eigen::Vector3f light_dir = Eigen::Vector3f::Constant(0.f); // TODO: replace this with more generic float[] of task-specific metadata.
+	ivec2 resolution = ivec2(0);
+	vec2 principal_point = vec2(0.5f);
+	vec2 focal_length = vec2(1000.f);
+	vec4 rolling_shutter = vec4(0.0f);
+	vec3 light_dir = vec3(0.f); // TODO: replace this with more generic float[] of task-specific metadata.
 };
 
 inline size_t image_type_size(EImageDataType type) {
@@ -63,6 +63,10 @@ inline size_t depth_type_size(EDepthDataType type) {
 }
 
 struct NerfDataset {
+	bool is_same(const NerfDataset& other) {
+		return xforms == other.xforms && paths == other.paths;
+	}
+
 	std::vector<tcnn::GPUMemory<Ray>> raymemory;
 	std::vector<tcnn::GPUMemory<uint8_t>> pixelmemory;
 	std::vector<tcnn::GPUMemory<float>> depthmemory;
@@ -75,15 +79,15 @@ struct NerfDataset {
 	std::vector<TrainingXForm> xforms;
 	std::vector<std::string> paths;
 	tcnn::GPUMemory<float> sharpness_data;
-	Eigen::Vector2i sharpness_resolution = {0, 0};
+	ivec2 sharpness_resolution = {0, 0};
 	tcnn::GPUMemory<float> envmap_data;
 
 	BoundingBox render_aabb = {};
-	Eigen::Matrix3f render_aabb_to_local = Eigen::Matrix3f::Identity();
-	Eigen::Vector3f up = {0.0f, 1.0f, 0.0f};
-	Eigen::Vector3f offset = {0.0f, 0.0f, 0.0f};
+	mat3 render_aabb_to_local = mat3(1.0f);
+	vec3 up = {0.0f, 1.0f, 0.0f};
+	vec3 offset = {0.0f, 0.0f, 0.0f};
 	size_t n_images = 0;
-	Eigen::Vector2i envmap_resolution = {0, 0};
+	ivec2 envmap_resolution = {0, 0};
 	float scale = 1.0f;
 	int aabb_scale = 1;
 	bool from_mitsuba = false;
@@ -98,68 +102,68 @@ struct NerfDataset {
 		return (has_light_dirs ? 3u : 0u) + n_extra_learnable_dims;
 	}
 
-	void set_training_image(int frame_idx, const Eigen::Vector2i& image_resolution, const void* pixels, const void* depth_pixels, float depth_scale, bool image_data_on_gpu, EImageDataType image_type, EDepthDataType depth_type, float sharpen_amount = 0.f, bool white_transparent = false, bool black_transparent = false, uint32_t mask_color = 0, const Ray *rays = nullptr);
+	void set_training_image(int frame_idx, const ivec2& image_resolution, const void* pixels, const void* depth_pixels, float depth_scale, bool image_data_on_gpu, EImageDataType image_type, EDepthDataType depth_type, float sharpen_amount = 0.f, bool white_transparent = false, bool black_transparent = false, uint32_t mask_color = 0, const Ray *rays = nullptr);
 
-	Eigen::Vector3f nerf_direction_to_ngp(const Eigen::Vector3f& nerf_dir) {
-		Eigen::Vector3f result = nerf_dir;
+	vec3 nerf_direction_to_ngp(const vec3& nerf_dir) {
+		vec3 result = nerf_dir;
 		if (from_mitsuba) {
 			result *= -1;
 		} else {
-			result = Eigen::Vector3f(result.y(), result.z(), result.x());
+			result = vec3(result.y, result.z, result.x);
 		}
 		return result;
 	}
 
-	Eigen::Matrix<float, 3, 4> nerf_matrix_to_ngp(const Eigen::Matrix<float, 3, 4>& nerf_matrix, bool scale_columns = false) const {
-		Eigen::Matrix<float, 3, 4> result = nerf_matrix;
-		result.col(0) *= scale_columns ? scale : 1.f;
-		result.col(1) *= scale_columns ? -scale : -1.f;
-		result.col(2) *= scale_columns ? -scale : -1.f;
-		result.col(3) = result.col(3) * scale + offset;
+	mat4x3 nerf_matrix_to_ngp(const mat4x3& nerf_matrix, bool scale_columns = false) const {
+		mat4x3 result = nerf_matrix;
+		result[0] *= scale_columns ? scale : 1.f;
+		result[1] *= scale_columns ? -scale : -1.f;
+		result[2] *= scale_columns ? -scale : -1.f;
+		result[3] = result[3] * scale + offset;
 
 		if (from_mitsuba) {
-			result.col(0) *= -1;
-			result.col(2) *= -1;
+			result[0] *= -1;
+			result[2] *= -1;
 		} else {
 			// Cycle axes xyz<-yzx
-			Eigen::Vector4f tmp = result.row(0);
-			result.row(0) = (Eigen::Vector4f)result.row(1);
-			result.row(1) = (Eigen::Vector4f)result.row(2);
-			result.row(2) = tmp;
+			vec4 tmp = row(result, 0);
+			result = row(result, 0, row(result, 1));
+			result = row(result, 1, row(result, 2));
+			result = row(result, 2, tmp);
 		}
 
 		return result;
 	}
 
-	Eigen::Matrix<float, 3, 4> ngp_matrix_to_nerf(const Eigen::Matrix<float, 3, 4>& ngp_matrix, bool scale_columns = false) const {
-		Eigen::Matrix<float, 3, 4> result = ngp_matrix;
+	mat4x3 ngp_matrix_to_nerf(const mat4x3& ngp_matrix, bool scale_columns = false) const {
+		mat4x3 result = ngp_matrix;
 		if (from_mitsuba) {
-			result.col(0) *= -1;
-			result.col(2) *= -1;
+			result[0] *= -1;
+			result[2] *= -1;
 		} else {
 			// Cycle axes xyz->yzx
-			Eigen::Vector4f tmp = result.row(0);
-			result.row(0) = (Eigen::Vector4f)result.row(2);
-			result.row(2) = (Eigen::Vector4f)result.row(1);
-			result.row(1) = tmp;
+			vec4 tmp = row(result, 0);
+			result = row(result, 0, row(result, 2));
+			result = row(result, 2, row(result, 1));
+			result = row(result, 1, tmp);
 		}
-		result.col(0) *= scale_columns ?  1.f/scale :  1.f;
-		result.col(1) *= scale_columns ? -1.f/scale : -1.f;
-		result.col(2) *= scale_columns ? -1.f/scale : -1.f;
-		result.col(3) = (result.col(3) - offset) / scale;
+		result[0] *= scale_columns ?  1.f/scale :  1.f;
+		result[1] *= scale_columns ? -1.f/scale : -1.f;
+		result[2] *= scale_columns ? -1.f/scale : -1.f;
+		result[3] = (result[3] - offset) / scale;
 		return result;
 	}
 
-	Eigen::Vector3f ngp_position_to_nerf(Eigen::Vector3f pos) const {
+	vec3 ngp_position_to_nerf(vec3 pos) const {
 		if (!from_mitsuba) {
-			pos = Eigen::Vector3f(pos.z(), pos.x(), pos.y());
+			pos = vec3(pos.z, pos.x, pos.y);
 		}
 		return (pos - offset) / scale;
 	}
 
-	Eigen::Vector3f nerf_position_to_ngp(const Eigen::Vector3f &pos) const {
-		Eigen::Vector3f rv = pos * scale + offset;
-		return from_mitsuba ? rv : Eigen::Vector3f(rv.y(), rv.z(), rv.x());
+	vec3 nerf_position_to_ngp(const vec3 &pos) const {
+		vec3 rv = pos * scale + offset;
+		return from_mitsuba ? rv : vec3(rv.y, rv.z, rv.x);
 	}
 
 	void nerf_ray_to_ngp(Ray& ray, bool scale_direction = false) {

--- a/include/neural-graphics-primitives/nerf_network.h
+++ b/include/neural-graphics-primitives/nerf_network.h
@@ -447,12 +447,20 @@ public:
 		}
 	}
 
-	const std::shared_ptr<tcnn::Encoding<T>>& encoding() const {
+	const std::shared_ptr<tcnn::Encoding<T>>& pos_encoding() const {
 		return m_pos_encoding;
 	}
 
 	const std::shared_ptr<tcnn::Encoding<T>>& dir_encoding() const {
 		return m_dir_encoding;
+	}
+
+	const std::shared_ptr<tcnn::Network<T>>& density_network() const {
+		return m_density_network;
+	}
+
+	const std::shared_ptr<tcnn::Network<T>>& rgb_network() const {
+		return m_rgb_network;
 	}
 
 	tcnn::json hyperparams() const override {
@@ -468,8 +476,8 @@ public:
 	}
 
 private:
-	std::unique_ptr<tcnn::Network<T>> m_density_network;
-	std::unique_ptr<tcnn::Network<T>> m_rgb_network;
+	std::shared_ptr<tcnn::Network<T>> m_density_network;
+	std::shared_ptr<tcnn::Network<T>> m_rgb_network;
 	std::shared_ptr<tcnn::Encoding<T>> m_pos_encoding;
 	std::shared_ptr<tcnn::Encoding<T>> m_dir_encoding;
 

--- a/include/neural-graphics-primitives/openxr_hmd.h
+++ b/include/neural-graphics-primitives/openxr_hmd.h
@@ -32,8 +32,6 @@
 #include <xr_dependencies.h>
 #include <openxr/openxr_platform.h>
 
-#include <Eigen/Dense>
-
 #include <tiny-cuda-nn/gpu_memory.h>
 
 #include <array>
@@ -76,18 +74,18 @@ public:
 			XrCompositionLayerProjectionView view{XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW};
 			XrCompositionLayerDepthInfoKHR depth_info{XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR};
 			std::shared_ptr<Buffer2D<uint8_t>> hidden_area_mask = nullptr;
-			Eigen::Matrix<float, 3, 4> pose;
+			mat4x3 pose;
 		};
 		struct Hand {
-			Eigen::Matrix<float, 3, 4> pose;
+			mat4x3 pose;
 			bool pose_active = false;
-			Eigen::Vector2f thumbstick = Eigen::Vector2f::Zero();
+			vec2 thumbstick = vec2(0.0f);
 			float grab_strength = 0.0f;
 			bool grabbing = false;
 			bool pressing = false;
-			Eigen::Vector3f grab_pos;
-			Eigen::Vector3f prev_grab_pos;
-			Eigen::Vector3f drag() const {
+			vec3 grab_pos;
+			vec3 prev_grab_pos;
+			vec3 drag() const {
 				return grab_pos - prev_grab_pos;
 			}
 		};

--- a/include/neural-graphics-primitives/render_buffer.h
+++ b/include/neural-graphics-primitives/render_buffer.h
@@ -33,8 +33,8 @@ class SurfaceProvider {
 public:
 	virtual cudaSurfaceObject_t surface() = 0;
 	virtual cudaArray_t array() = 0;
-	virtual Eigen::Vector2i resolution() const = 0;
-	virtual void resize(const Eigen::Vector2i&, int n_channels = 4) = 0;
+	virtual ivec2 resolution() const = 0;
+	virtual void resize(const ivec2&, int n_channels = 4) = 0;
 };
 
 class CudaSurface2D : public SurfaceProvider {
@@ -50,7 +50,7 @@ public:
 
 	void free();
 
-	void resize(const Eigen::Vector2i& size, int n_channels) override;
+	void resize(const ivec2& size, int n_channels) override;
 
 	cudaSurfaceObject_t surface() override {
 		return m_surface;
@@ -60,12 +60,12 @@ public:
 		return m_array;
 	}
 
-	Eigen::Vector2i resolution() const override {
+	ivec2 resolution() const override {
 		return m_size;
 	}
 
 private:
-	Eigen::Vector2i m_size = Eigen::Vector2i::Zero();
+	ivec2 m_size = ivec2(0);
 	int m_n_channels = 0;
 	cudaArray_t m_array;
 	cudaSurfaceObject_t m_surface;
@@ -108,24 +108,24 @@ public:
 
 	void load(const fs::path& path);
 
-	void load(const float* data, Eigen::Vector2i new_size, int n_channels);
+	void load(const float* data, ivec2 new_size, int n_channels);
 
-	void load(const uint8_t* data, Eigen::Vector2i new_size, int n_channels);
+	void load(const uint8_t* data, ivec2 new_size, int n_channels);
 
-	void resize(const Eigen::Vector2i& new_size, int n_channels, bool is_8bit);
+	void resize(const ivec2& new_size, int n_channels, bool is_8bit);
 
-	void resize(const Eigen::Vector2i& new_size, int n_channels) override {
+	void resize(const ivec2& new_size, int n_channels) override {
 		resize(new_size, n_channels, false);
 	}
 
-	Eigen::Vector2i resolution() const override {
+	ivec2 resolution() const override {
 		return m_size;
 	}
 
 private:
 	class CUDAMapping {
 	public:
-		CUDAMapping(GLuint texture_id, const Eigen::Vector2i& size, int n_channels);
+		CUDAMapping(GLuint texture_id, const ivec2& size, int n_channels);
 		~CUDAMapping();
 
 		cudaSurfaceObject_t surface() const { return m_cuda_surface ? m_cuda_surface->surface() : m_surface; }
@@ -141,7 +141,7 @@ private:
 		cudaArray_t m_mapped_array = {};
 		cudaSurfaceObject_t m_surface = {};
 
-		Eigen::Vector2i m_size;
+		ivec2 m_size;
 		int m_n_channels;
 		std::vector<float> m_data_cpu;
 
@@ -150,7 +150,7 @@ private:
 
 	std::string m_texture_name;
 	GLuint m_texture_id = 0;
-	Eigen::Vector2i m_size = Eigen::Vector2i::Constant(0);
+	ivec2 m_size = ivec2(0);
 	int m_n_channels = 0;
 	GLint m_internal_format;
 	GLenum m_format;
@@ -160,9 +160,9 @@ private:
 #endif //NGP_GUI
 
 struct CudaRenderBufferView {
-	Eigen::Array4f* frame_buffer = nullptr;
+	vec4* frame_buffer = nullptr;
 	float* depth_buffer = nullptr;
-	Eigen::Vector2i resolution = Eigen::Vector2i::Zero();
+	ivec2 resolution = ivec2(0);
 	uint32_t spp = 0;
 
 	std::shared_ptr<Buffer2D<uint8_t>> hidden_area_mask = nullptr;
@@ -183,15 +183,15 @@ public:
 		return m_rgba_target->surface();
 	}
 
-	Eigen::Vector2i in_resolution() const {
+	ivec2 in_resolution() const {
 		return m_in_resolution;
 	}
 
-	Eigen::Vector2i out_resolution() const {
+	ivec2 out_resolution() const {
 		return m_rgba_target->resolution();
 	}
 
-	void resize(const Eigen::Vector2i& res);
+	void resize(const ivec2& res);
 
 	void reset_accumulation() {
 		m_spp = 0;
@@ -205,7 +205,7 @@ public:
 		m_spp = value;
 	}
 
-	Eigen::Array4f* frame_buffer() const {
+	vec4* frame_buffer() const {
 		return m_frame_buffer.data();
 	}
 
@@ -213,7 +213,7 @@ public:
 		return m_depth_buffer.data();
 	}
 
-	Eigen::Array4f* accumulate_buffer() const {
+	vec4* accumulate_buffer() const {
 		return m_accumulate_buffer.data();
 	}
 
@@ -231,19 +231,19 @@ public:
 
 	void accumulate(float exposure, cudaStream_t stream);
 
-	void tonemap(float exposure, const Eigen::Array4f& background_color, EColorSpace output_color_space, float znear, float zfar, bool snap_to_pixel_centers, cudaStream_t stream);
+	void tonemap(float exposure, const vec4& background_color, EColorSpace output_color_space, float znear, float zfar, bool snap_to_pixel_centers, cudaStream_t stream);
 
 	void overlay_image(
 		float alpha,
-		const Eigen::Array3f& exposure,
-		const Eigen::Array4f& background_color,
+		const vec3& exposure,
+		const vec4& background_color,
 		EColorSpace output_color_space,
 		const void* __restrict__ image,
 		EImageDataType image_data_type,
-		const Eigen::Vector2i& resolution,
+		const ivec2& resolution,
 		int fov_axis,
 		float zoom,
-		const Eigen::Vector2f& screen_center,
+		const vec2& screen_center,
 		cudaStream_t stream
 	);
 
@@ -251,14 +251,14 @@ public:
 		float alpha,
 		const float* __restrict__ depth,
 		float depth_scale,
-		const Eigen::Vector2i& resolution,
+		const ivec2& resolution,
 		int fov_axis,
 		float zoom,
-		const Eigen::Vector2f& screen_center,
+		const vec2& screen_center,
 		cudaStream_t stream
 	);
 
-	void overlay_false_color(Eigen::Vector2i training_resolution, bool to_srgb, int fov_axis, cudaStream_t stream, const float *error_map, Eigen::Vector2i error_map_resolution, const float *average, float brightness, bool viridis);
+	void overlay_false_color(ivec2 training_resolution, bool to_srgb, int fov_axis, cudaStream_t stream, const float *error_map, ivec2 error_map_resolution, const float *average, float brightness, bool viridis);
 
 	SurfaceProvider& surface_provider() {
 		return *m_rgba_target;
@@ -278,7 +278,7 @@ public:
 		}
 	}
 
-	void enable_dlss(IDlssProvider& dlss_provider, const Eigen::Vector2i& max_out_res);
+	void enable_dlss(IDlssProvider& dlss_provider, const ivec2& max_out_res);
 	void disable_dlss();
 	void set_dlss_sharpening(float value) {
 		m_dlss_sharpening = value;
@@ -304,11 +304,11 @@ private:
 	std::unique_ptr<IDlss> m_dlss;
 	float m_dlss_sharpening = 0.0f;
 
-	Eigen::Vector2i m_in_resolution = Eigen::Vector2i::Zero();
+	ivec2 m_in_resolution = ivec2(0);
 
-	tcnn::GPUMemory<Eigen::Array4f> m_frame_buffer;
+	tcnn::GPUMemory<vec4> m_frame_buffer;
 	tcnn::GPUMemory<float> m_depth_buffer;
-	tcnn::GPUMemory<Eigen::Array4f> m_accumulate_buffer;
+	tcnn::GPUMemory<vec4> m_accumulate_buffer;
 
 	std::shared_ptr<Buffer2D<uint8_t>> m_hidden_area_mask = nullptr;
 

--- a/include/neural-graphics-primitives/sdf.h
+++ b/include/neural-graphics-primitives/sdf.h
@@ -21,7 +21,7 @@
 NGP_NAMESPACE_BEGIN
 
 struct SdfPayload {
-	Eigen::Vector3f dir;
+	vec3 dir;
 	uint32_t idx;
 	uint16_t n_steps;
 	bool alive;
@@ -30,8 +30,8 @@ struct SdfPayload {
 struct RaysSdfSoa {
 #if defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))
 	void copy_from_other_async(uint32_t n_elements, const RaysSdfSoa& other, cudaStream_t stream) {
-		CUDA_CHECK_THROW(cudaMemcpyAsync(pos, other.pos, n_elements * sizeof(Eigen::Vector3f), cudaMemcpyDeviceToDevice, stream));
-		CUDA_CHECK_THROW(cudaMemcpyAsync(normal, other.normal, n_elements * sizeof(Eigen::Vector3f), cudaMemcpyDeviceToDevice, stream));
+		CUDA_CHECK_THROW(cudaMemcpyAsync(pos, other.pos, n_elements * sizeof(vec3), cudaMemcpyDeviceToDevice, stream));
+		CUDA_CHECK_THROW(cudaMemcpyAsync(normal, other.normal, n_elements * sizeof(vec3), cudaMemcpyDeviceToDevice, stream));
 		CUDA_CHECK_THROW(cudaMemcpyAsync(distance, other.distance, n_elements * sizeof(float), cudaMemcpyDeviceToDevice, stream));
 		CUDA_CHECK_THROW(cudaMemcpyAsync(prev_distance, other.prev_distance, n_elements * sizeof(float), cudaMemcpyDeviceToDevice, stream));
 		CUDA_CHECK_THROW(cudaMemcpyAsync(total_distance, other.total_distance, n_elements * sizeof(float), cudaMemcpyDeviceToDevice, stream));
@@ -40,7 +40,7 @@ struct RaysSdfSoa {
 	}
 #endif
 
-	void set(Eigen::Vector3f* pos, Eigen::Vector3f* normal, float* distance, float* prev_distance, float* total_distance, float* min_visibility, SdfPayload* payload) {
+	void set(vec3* pos, vec3* normal, float* distance, float* prev_distance, float* total_distance, float* min_visibility, SdfPayload* payload) {
 		this->pos = pos;
 		this->normal = normal;
 		this->distance = distance;
@@ -50,8 +50,8 @@ struct RaysSdfSoa {
 		this->payload = payload;
 	}
 
-	Eigen::Vector3f* pos;
-	Eigen::Vector3f* normal;
+	vec3* pos;
+	vec3* normal;
 	float* distance;
 	float* prev_distance;
 	float* total_distance;
@@ -67,8 +67,8 @@ struct BRDFParams {
 	float sheen=0.f;
 	float clearcoat=0.f;
 	float clearcoat_gloss=0.f;
-	Eigen::Vector3f basecolor=Eigen::Vector3f(0.8f,0.8f,0.8f);
-	Eigen::Vector3f ambientcolor=Eigen::Vector3f(0.f,0.f,0.f);
+	vec3 basecolor=vec3(0.8f,0.8f,0.8f);
+	vec3 ambientcolor=vec3(0.f,0.f,0.f);
 };
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -63,7 +63,6 @@ class GLTexture;
 
 class Testbed {
 public:
-	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 	Testbed(ETestbedMode mode = ETestbedMode::None);
 	~Testbed();
 
@@ -79,8 +78,8 @@ public:
 
 	void set_mode(ETestbedMode mode);
 
-	using distance_fun_t = std::function<void(uint32_t, const Eigen::Vector3f*, float*, cudaStream_t)>;
-	using normals_fun_t = std::function<void(uint32_t, const Eigen::Vector3f*, Eigen::Vector3f*, cudaStream_t)>;
+	using distance_fun_t = std::function<void(uint32_t, const vec3*, float*, cudaStream_t)>;
+	using normals_fun_t = std::function<void(uint32_t, const vec3*, vec3*, cudaStream_t)>;
 
 	class SphereTracer {
 	public:
@@ -88,11 +87,11 @@ public:
 
 		void init_rays_from_camera(
 			uint32_t spp,
-			const Eigen::Vector2i& resolution,
-			const Eigen::Vector2f& focal_length,
-			const Eigen::Matrix<float, 3, 4>& camera_matrix,
-			const Eigen::Vector2f& screen_center,
-			const Eigen::Vector3f& parallax_shift,
+			const ivec2& resolution,
+			const vec2& focal_length,
+			const mat4x3& camera_matrix,
+			const vec2& screen_center,
+			const vec3& parallax_shift,
 			bool snap_to_pixel_centers,
 			const BoundingBox& aabb,
 			float floor_y,
@@ -100,8 +99,8 @@ public:
 			float plane_z,
 			float aperture_size,
 			const Foveation& foveation,
-			const Buffer2DView<const Eigen::Array4f>& envmap,
-			Eigen::Array4f* frame_buffer,
+			const Buffer2DView<const vec4>& envmap,
+			vec4* frame_buffer,
 			float* depth_buffer,
 			const Buffer2DView<const uint8_t>& hidden_area_mask,
 			const TriangleOctree* octree,
@@ -149,28 +148,29 @@ public:
 			uint32_t spp,
 			uint32_t padded_output_width,
 			uint32_t n_extra_dims,
-			const Eigen::Vector2i& resolution,
-			const Eigen::Vector2f& focal_length,
-			const Eigen::Matrix<float, 3, 4>& camera_matrix0,
-			const Eigen::Matrix<float, 3, 4>& camera_matrix1,
-			const Eigen::Vector4f& rolling_shutter,
-			const Eigen::Vector2f& screen_center,
-			const Eigen::Vector3f& parallax_shift,
+			const ivec2& resolution,
+			const vec2& focal_length,
+			const mat4x3& camera_matrix0,
+			const mat4x3& camera_matrix1,
+			const vec4& rolling_shutter,
+			const vec2& screen_center,
+			const vec3& parallax_shift,
 			bool snap_to_pixel_centers,
 			const BoundingBox& render_aabb,
-			const Eigen::Matrix3f& render_aabb_to_local,
+			const mat3& render_aabb_to_local,
 			float near_distance,
 			float plane_z,
 			float aperture_size,
 			const Foveation& foveation,
 			const Lens& lens,
-			const Buffer2DView<const Eigen::Array4f>& envmap,
-			const Buffer2DView<const Eigen::Vector2f>& distortion,
-			Eigen::Array4f* frame_buffer,
+			const Buffer2DView<const vec4>& envmap,
+			const Buffer2DView<const vec2>& distortion,
+			vec4* frame_buffer,
 			float* depth_buffer,
 			const Buffer2DView<const uint8_t>& hidden_area_mask,
 			const uint8_t* grid,
 			int show_accel,
+			uint32_t max_mip,
 			float cone_angle_constant,
 			ERenderMode render_mode,
 			cudaStream_t stream
@@ -179,19 +179,20 @@ public:
 		uint32_t trace(
 			NerfNetwork<precision_t>& network,
 			const BoundingBox& render_aabb,
-			const Eigen::Matrix3f& render_aabb_to_local,
+			const mat3& render_aabb_to_local,
 			const BoundingBox& train_aabb,
-			const Eigen::Vector2f& focal_length,
+			const vec2& focal_length,
 			float cone_angle_constant,
 			const uint8_t* grid,
 			ERenderMode render_mode,
-			const Eigen::Matrix<float, 3, 4> &camera_matrix,
+			const mat4x3 &camera_matrix,
 			float depth_scale,
 			int visualized_layer,
 			int visualized_dim,
 			ENerfActivation rgb_activation,
 			ENerfActivation density_activation,
 			int show_accel,
+			uint32_t max_mip,
 			float min_transmittance,
 			float glow_y_cutoff,
 			int glow_mode,
@@ -218,12 +219,12 @@ public:
 	class FiniteDifferenceNormalsApproximator {
 	public:
 		void enlarge(uint32_t n_elements, cudaStream_t stream);
-		void normal(uint32_t n_elements, const distance_fun_t& distance_function, const Eigen::Vector3f* pos, Eigen::Vector3f* normal, float epsilon, cudaStream_t stream);
+		void normal(uint32_t n_elements, const distance_fun_t& distance_function, const vec3* pos, vec3* normal, float epsilon, cudaStream_t stream);
 
 	private:
-		Eigen::Vector3f* dx;
-		Eigen::Vector3f* dy;
-		Eigen::Vector3f* dz;
+		vec3* dx;
+		vec3* dy;
+		vec3* dz;
 
 		float* dist_dx_pos;
 		float* dist_dy_pos;
@@ -283,11 +284,11 @@ public:
 		const CudaRenderBufferView& render_buffer,
 		NerfNetwork<precision_t>& nerf_network,
 		const uint8_t* density_grid_bitfield,
-		const Eigen::Vector2f& focal_length,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix0,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix1,
-		const Eigen::Vector4f& rolling_shutter,
-		const Eigen::Vector2f& screen_center,
+		const vec2& focal_length,
+		const mat4x3& camera_matrix0,
+		const mat4x3& camera_matrix1,
+		const vec4& rolling_shutter,
+		const vec2& screen_center,
 		const Foveation& foveation,
 		int visualized_dimension
 	);
@@ -296,38 +297,38 @@ public:
 		const distance_fun_t& distance_function,
 		const normals_fun_t& normals_function,
 		const CudaRenderBufferView& render_buffer,
-		const Eigen::Vector2f& focal_length,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix,
-		const Eigen::Vector2f& screen_center,
+		const vec2& focal_length,
+		const mat4x3& camera_matrix,
+		const vec2& screen_center,
 		const Foveation& foveation,
 		int visualized_dimension
 	);
 	void render_image(
 		cudaStream_t stream,
 		const CudaRenderBufferView& render_buffer,
-		const Eigen::Vector2f& focal_length,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix,
-		const Eigen::Vector2f& screen_center,
+		const vec2& focal_length,
+		const mat4x3& camera_matrix,
+		const vec2& screen_center,
 		const Foveation& foveation,
 		int visualized_dimension
 	);
 	void render_volume(
 		cudaStream_t stream,
 		const CudaRenderBufferView& render_buffer,
-		const Eigen::Vector2f& focal_length,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix,
-		const Eigen::Vector2f& screen_center,
+		const vec2& focal_length,
+		const mat4x3& camera_matrix,
+		const vec2& screen_center,
 		const Foveation& foveation
 	);
 
 	void render_frame(
 		cudaStream_t stream,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix0,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix1,
-		const Eigen::Matrix<float, 3, 4>& prev_camera_matrix,
-		const Eigen::Vector2f& screen_center,
-		const Eigen::Vector2f& relative_focal_length,
-		const Eigen::Vector4f& nerf_rolling_shutter,
+		const mat4x3& camera_matrix0,
+		const mat4x3& camera_matrix1,
+		const mat4x3& prev_camera_matrix,
+		const vec2& screen_center,
+		const vec2& relative_focal_length,
+		const vec4& nerf_rolling_shutter,
 		const Foveation& foveation,
 		const Foveation& prev_foveation,
 		int visualized_dimension,
@@ -337,26 +338,26 @@ public:
 	);
 	void render_frame_main(
 		CudaDevice& device,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix0,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix1,
-		const Eigen::Vector2f& screen_center,
-		const Eigen::Vector2f& relative_focal_length,
-		const Eigen::Vector4f& nerf_rolling_shutter,
+		const mat4x3& camera_matrix0,
+		const mat4x3& camera_matrix1,
+		const vec2& screen_center,
+		const vec2& relative_focal_length,
+		const vec4& nerf_rolling_shutter,
 		const Foveation& foveation,
 		int visualized_dimension
 	);
 	void render_frame_epilogue(
 		cudaStream_t stream,
-		const Eigen::Matrix<float, 3, 4>& camera_matrix0,
-		const Eigen::Matrix<float, 3, 4>& prev_camera_matrix,
-		const Eigen::Vector2f& screen_center,
-		const Eigen::Vector2f& relative_focal_length,
+		const mat4x3& camera_matrix0,
+		const mat4x3& prev_camera_matrix,
+		const vec2& screen_center,
+		const vec2& relative_focal_length,
 		const Foveation& foveation,
 		const Foveation& prev_foveation,
 		CudaRenderBuffer& render_buffer,
 		bool to_srgb = true
 	);
-	void visualize_nerf_cameras(ImDrawList* list, const Eigen::Matrix<float, 4, 4>& world2proj);
+	void visualize_nerf_cameras(ImDrawList* list, const mat4& world2proj);
 	fs::path find_network_config(const fs::path& network_config_path);
 	nlohmann::json load_network_config(const fs::path& network_config_path);
 	void reload_network_from_file(const fs::path& path = "");
@@ -374,24 +375,23 @@ public:
 	void load_mesh(const fs::path& data_path);
 	void set_exposure(float exposure) { m_exposure = exposure; }
 	void set_max_level(float maxlevel);
-	void set_min_level(float minlevel);
 	void set_visualized_dim(int dim);
 	void set_visualized_layer(int layer);
-	void translate_camera(const Eigen::Vector3f& rel, const Eigen::Matrix3f& rot, bool allow_up_down = true);
-	Eigen::Matrix3f rotation_from_angles(const Eigen::Vector2f& angles) const;
+	void translate_camera(const vec3& rel, const mat3& rot, bool allow_up_down = true);
+	mat3 rotation_from_angles(const vec2& angles) const;
 	void mouse_drag();
 	void mouse_wheel();
 	void load_file(const fs::path& path);
-	void set_nerf_camera_matrix(const Eigen::Matrix<float, 3, 4>& cam);
-	Eigen::Vector3f look_at() const;
-	void set_look_at(const Eigen::Vector3f& pos);
+	void set_nerf_camera_matrix(const mat4x3& cam);
+	vec3 look_at() const;
+	void set_look_at(const vec3& pos);
 	float scale() const { return m_scale; }
 	void set_scale(float scale);
-	Eigen::Vector3f view_pos() const { return m_camera.col(3); }
-	Eigen::Vector3f view_dir() const { return m_camera.col(2); }
-	Eigen::Vector3f view_up() const { return m_camera.col(1); }
-	Eigen::Vector3f view_side() const { return m_camera.col(0); }
-	void set_view_dir(const Eigen::Vector3f& dir);
+	vec3 view_pos() const { return m_camera[3]; }
+	vec3 view_dir() const { return m_camera[2]; }
+	vec3 view_up() const { return m_camera[1]; }
+	vec3 view_side() const { return m_camera[0]; }
+	void set_view_dir(const vec3& dir);
 	void first_training_view();
 	void last_training_view();
 	void previous_training_view();
@@ -399,10 +399,10 @@ public:
 	void set_camera_to_training_view(int trainview);
 	void reset_camera();
 	bool keyboard_event();
-	void generate_training_samples_sdf(Eigen::Vector3f* positions, float* distances, uint32_t n_to_generate, cudaStream_t stream, bool uniform_only);
+	void generate_training_samples_sdf(vec3* positions, float* distances, uint32_t n_to_generate, cudaStream_t stream, bool uniform_only);
 	void update_density_grid_nerf(float decay, uint32_t n_uniform_density_grid_samples, uint32_t n_nonuniform_density_grid_samples, cudaStream_t stream);
 	void update_density_grid_mean_and_bitfield(cudaStream_t stream);
-	void mark_density_grid_in_sphere_empty(const Eigen::Vector3f& pos, float radius, cudaStream_t stream);
+	void mark_density_grid_in_sphere_empty(const vec3& pos, float radius, cudaStream_t stream);
 
 	struct NerfCounters {
 		tcnn::GPUMemory<uint32_t> numsteps_counter; // number of steps each ray took
@@ -433,24 +433,24 @@ public:
 	void training_prep_sdf(uint32_t batch_size, cudaStream_t stream);
 	void training_prep_image(uint32_t batch_size, cudaStream_t stream) {}
 	void train(uint32_t batch_size);
-	Eigen::Vector2f calc_focal_length(const Eigen::Vector2i& resolution, const Eigen::Vector2f& relative_focal_length, int fov_axis, float zoom) const;
-	Eigen::Vector2f render_screen_center(const Eigen::Vector2f& screen_center) const;
+	vec2 calc_focal_length(const ivec2& resolution, const vec2& relative_focal_length, int fov_axis, float zoom) const;
+	vec2 render_screen_center(const vec2& screen_center) const;
 	void optimise_mesh_step(uint32_t N_STEPS);
 	void compute_mesh_vertex_colors();
-	tcnn::GPUMemory<float> get_density_on_grid(Eigen::Vector3i res3d, const BoundingBox& aabb, const Eigen::Matrix3f& render_aabb_to_local); // network version (nerf or sdf)
-	tcnn::GPUMemory<float> get_sdf_gt_on_grid(Eigen::Vector3i res3d, const BoundingBox& aabb, const Eigen::Matrix3f& render_aabb_to_local); // sdf gt version (sdf only)
-	tcnn::GPUMemory<Eigen::Array4f> get_rgba_on_grid(Eigen::Vector3i res3d, Eigen::Vector3f ray_dir, bool voxel_centers, float depth, bool density_as_alpha = false);
-	int marching_cubes(Eigen::Vector3i res3d, const BoundingBox& render_aabb, const Eigen::Matrix3f& render_aabb_to_local, float thresh);
+	tcnn::GPUMemory<float> get_density_on_grid(ivec3 res3d, const BoundingBox& aabb, const mat3& render_aabb_to_local); // network version (nerf or sdf)
+	tcnn::GPUMemory<float> get_sdf_gt_on_grid(ivec3 res3d, const BoundingBox& aabb, const mat3& render_aabb_to_local); // sdf gt version (sdf only)
+	tcnn::GPUMemory<vec4> get_rgba_on_grid(ivec3 res3d, vec3 ray_dir, bool voxel_centers, float depth, bool density_as_alpha = false);
+	int marching_cubes(ivec3 res3d, const BoundingBox& render_aabb, const mat3& render_aabb_to_local, float thresh);
 
-	float get_depth_from_renderbuffer(const CudaRenderBuffer& render_buffer, const Eigen::Vector2f& uv);
-	Eigen::Vector3f get_3d_pos_from_pixel(const CudaRenderBuffer& render_buffer, const Eigen::Vector2i& focus_pixel);
+	float get_depth_from_renderbuffer(const CudaRenderBuffer& render_buffer, const vec2& uv);
+	vec3 get_3d_pos_from_pixel(const CudaRenderBuffer& render_buffer, const ivec2& focus_pixel);
 	void autofocus();
 	size_t n_params();
 	size_t first_encoder_param();
 	size_t n_encoding_params();
 
 #ifdef NGP_PYTHON
-	pybind11::dict compute_marching_cubes_mesh(Eigen::Vector3i res3d = Eigen::Vector3i::Constant(128), BoundingBox aabb = BoundingBox{Eigen::Vector3f::Zero(), Eigen::Vector3f::Ones()}, float thresh=2.5f);
+	pybind11::dict compute_marching_cubes_mesh(ivec3 res3d = ivec3(128), BoundingBox aabb = BoundingBox{vec3(0.0f), vec3(1.0f)}, float thresh=2.5f);
 	pybind11::array_t<float> render_to_cpu(int width, int height, int spp, bool linear, float start_t, float end_t, float fps, float shutter_fraction);
 	pybind11::array_t<float> view(bool linear, size_t view) const;
 	pybind11::array_t<float> screenshot(bool linear, bool front_buffer) const;
@@ -458,7 +458,7 @@ public:
 #endif
 
 	double calculate_iou(uint32_t n_samples=128*1024*1024, float scale_existing_results_factor=0.0, bool blocking=true, bool force_use_octree = true);
-	void draw_visualizations(ImDrawList* list, const Eigen::Matrix<float, 3, 4>& camera_matrix);
+	void draw_visualizations(ImDrawList* list, const mat4x3& camera_matrix);
 	void train_and_render(bool skip_rendering);
 	fs::path training_data_path() const;
 	void init_window(int resw, int resh, bool hidden = false, bool second_window = false);
@@ -469,7 +469,7 @@ public:
 	int find_best_training_view(int default_view);
 	bool begin_frame();
 	void handle_user_input();
-	Eigen::Vector3f vr_to_world(const Eigen::Vector3f& pos) const;
+	vec3 vr_to_world(const vec3& pos) const;
 	void begin_vr_frame_and_handle_vr_input();
 	void gather_histograms();
 	void draw_gui();
@@ -482,8 +482,8 @@ public:
 	uint32_t n_dimensions_to_visualize() const;
 	float fov() const ;
 	void set_fov(float val) ;
-	Eigen::Vector2f fov_xy() const ;
-	void set_fov_xy(const Eigen::Vector2f& val);
+	vec2 fov_xy() const ;
+	void set_fov_xy(const vec2& val);
 	void save_snapshot(const fs::path& path, bool include_optimizer_state, bool compress);
 	void load_snapshot(const fs::path& path);
 	CameraKeyframe copy_camera_to_keyframe() const;
@@ -496,8 +496,8 @@ public:
 
 	float compute_image_mse(bool quantize_to_byte);
 
-	void compute_and_save_marching_cubes_mesh(const char* filename, Eigen::Vector3i res3d = Eigen::Vector3i::Constant(128), BoundingBox aabb = {}, float thresh = 2.5f, bool unwrap_it = false);
-	Eigen::Vector3i compute_and_save_png_slices(const char* filename, int res, BoundingBox aabb = {}, float thresh = 2.5f, float density_range = 4.f, bool flip_y_and_z_axes = false);
+	void compute_and_save_marching_cubes_mesh(const char* filename, ivec3 res3d = ivec3(128), BoundingBox aabb = {}, float thresh = 2.5f, bool unwrap_it = false);
+	ivec3 compute_and_save_png_slices(const char* filename, int res, BoundingBox aabb = {}, float thresh = 2.5f, float density_range = 4.f, bool flip_y_and_z_axes = false);
 
 	fs::path root_dir();
 
@@ -511,12 +511,12 @@ public:
 		float density_amount = 128.f;
 		float inflate_amount = 1.f;
 		bool optimize_mesh = false;
-		tcnn::GPUMemory<Eigen::Vector3f> verts;
-		tcnn::GPUMemory<Eigen::Vector3f> vert_normals;
-		tcnn::GPUMemory<Eigen::Vector3f> vert_colors;
-		tcnn::GPUMemory<Eigen::Vector4f> verts_smoothed; // homogenous
+		tcnn::GPUMemory<vec3> verts;
+		tcnn::GPUMemory<vec3> vert_normals;
+		tcnn::GPUMemory<vec3> vert_colors;
+		tcnn::GPUMemory<vec4> verts_smoothed; // homogenous
 		tcnn::GPUMemory<uint32_t> indices;
-		tcnn::GPUMemory<Eigen::Vector3f> verts_gradient;
+		tcnn::GPUMemory<vec3> verts_gradient;
 		std::shared_ptr<TrainableBuffer<3, 1, float>> trainable_verts;
 		std::shared_ptr<tcnn::Optimizer<float>> verts_optimizer;
 
@@ -551,33 +551,33 @@ public:
 	bool m_max_level_rand_training = false;
 
 	// Rendering stuff
-	Eigen::Vector2i m_window_res = Eigen::Vector2i::Constant(0);
+	ivec2 m_window_res = ivec2(0);
 	bool m_dynamic_res = true;
 	float m_dynamic_res_target_fps = 20.0f;
 	int m_fixed_res_factor = 8;
 	float m_scale = 1.0;
 	float m_aperture_size = 0.0f;
-	Eigen::Vector2f m_relative_focal_length = Eigen::Vector2f::Ones();
+	vec2 m_relative_focal_length = vec2(1.0f);
 	uint32_t m_fov_axis = 1;
 	float m_zoom = 1.f; // 2d zoom factor (for insets?)
-	Eigen::Vector2f m_screen_center = Eigen::Vector2f::Constant(0.5f); // center of 2d zoom
+	vec2 m_screen_center = vec2(0.5f); // center of 2d zoom
 
 	float m_ndc_znear = 1.0f / 32.0f;
 	float m_ndc_zfar = 128.0f;
 
-	Eigen::Matrix<float, 3, 4> m_camera = Eigen::Matrix<float, 3, 4>::Zero();
-	Eigen::Matrix<float, 3, 4> m_smoothed_camera = Eigen::Matrix<float, 3, 4>::Zero();
+	mat4x3 m_camera = mat4x3(1.0f);
+	mat4x3 m_smoothed_camera = mat4x3(1.0f);
 	size_t m_render_skip_due_to_lack_of_camera_movement_counter = 0;
 
 	bool m_fps_camera = false;
 	bool m_camera_smoothing = false;
 	bool m_autofocus = false;
-	Eigen::Vector3f m_autofocus_target = Eigen::Vector3f::Constant(0.5f);
+	vec3 m_autofocus_target = vec3(0.5f);
 
 	CameraPath m_camera_path = {};
 
-	Eigen::Vector3f m_up_dir = {0.0f, 1.0f, 0.0f};
-	Eigen::Vector3f m_sun_dir = Eigen::Vector3f::Ones().normalized();
+	vec3 m_up_dir = {0.0f, 1.0f, 0.0f};
+	vec3 m_sun_dir = normalize(vec3(1.0f));
 	float m_bounding_radius = 1;
 	float m_exposure = 0.f;
 
@@ -602,7 +602,7 @@ public:
 	GLuint m_blit_program = 0;
 
 	void init_opengl_shaders();
-	void blit_texture(const Foveation& foveation, GLint rgba_texture, GLint rgba_filter_mode, GLint depth_texture, GLint framebuffer, const Eigen::Vector2i& offset, const Eigen::Vector2i& resolution);
+	void blit_texture(const Foveation& foveation, GLint rgba_texture, GLint rgba_filter_mode, GLint depth_texture, GLint framebuffer, const ivec2& offset, const ivec2& resolution);
 
 	void create_second_window();
 
@@ -643,35 +643,35 @@ public:
 				tcnn::GPUMemory<float> cdf_y;
 				tcnn::GPUMemory<float> cdf_img;
 				std::vector<float> pmf_img_cpu;
-				Eigen::Vector2i resolution = {16, 16};
-				Eigen::Vector2i cdf_resolution = {16, 16};
+				ivec2 resolution = {16, 16};
+				ivec2 cdf_resolution = {16, 16};
 				bool is_cdf_valid = false;
 			} error_map;
 
 			std::vector<TrainingXForm> transforms;
 			tcnn::GPUMemory<TrainingXForm> transforms_gpu;
 
-			std::vector<Eigen::Vector3f> cam_pos_gradient;
-			tcnn::GPUMemory<Eigen::Vector3f> cam_pos_gradient_gpu;
+			std::vector<vec3> cam_pos_gradient;
+			tcnn::GPUMemory<vec3> cam_pos_gradient_gpu;
 
-			std::vector<Eigen::Vector3f> cam_rot_gradient;
-			tcnn::GPUMemory<Eigen::Vector3f> cam_rot_gradient_gpu;
+			std::vector<vec3> cam_rot_gradient;
+			tcnn::GPUMemory<vec3> cam_rot_gradient_gpu;
 
-			tcnn::GPUMemory<Eigen::Array3f> cam_exposure_gpu;
-			std::vector<Eigen::Array3f> cam_exposure_gradient;
-			tcnn::GPUMemory<Eigen::Array3f> cam_exposure_gradient_gpu;
+			tcnn::GPUMemory<vec3> cam_exposure_gpu;
+			std::vector<vec3> cam_exposure_gradient;
+			tcnn::GPUMemory<vec3> cam_exposure_gradient_gpu;
 
-			Eigen::Vector2f cam_focal_length_gradient = Eigen::Vector2f::Zero();
-			tcnn::GPUMemory<Eigen::Vector2f> cam_focal_length_gradient_gpu;
+			vec2 cam_focal_length_gradient = vec2(0.0f);
+			tcnn::GPUMemory<vec2> cam_focal_length_gradient_gpu;
 
-			std::vector<AdamOptimizer<Eigen::Array3f>> cam_exposure;
-			std::vector<AdamOptimizer<Eigen::Vector3f>> cam_pos_offset;
+			std::vector<AdamOptimizer<vec3>> cam_exposure;
+			std::vector<AdamOptimizer<vec3>> cam_pos_offset;
 			std::vector<RotationAdamOptimizer> cam_rot_offset;
-			AdamOptimizer<Eigen::Vector2f> cam_focal_length_offset = AdamOptimizer<Eigen::Vector2f>(0.f);
+			AdamOptimizer<vec2> cam_focal_length_offset = AdamOptimizer<vec2>(0.0f);
 
 			tcnn::GPUMemory<float> extra_dims_gpu; // if the model demands a latent code per training image, we put them in here.
 			tcnn::GPUMemory<float> extra_dims_gradient_gpu;
-			std::vector<AdamOptimizer<Eigen::ArrayXf>> extra_dims_opt;
+			std::vector<VarAdamOptimizer> extra_dims_opt;
 
 			void reset_extra_dims(default_rng_t &rng);
 
@@ -717,10 +717,11 @@ public:
 			tcnn::GPUMemory<float> sharpness_grid;
 
 			void set_camera_intrinsics(int frame_idx, float fx, float fy = 0.0f, float cx = -0.5f, float cy = -0.5f, float k1 = 0.0f, float k2 = 0.0f, float p1 = 0.0f, float p2 = 0.0f, float k3 = 0.0f, float k4 = 0.0f, bool is_fisheye = false);
-			void set_camera_extrinsics_rolling_shutter(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world_start, Eigen::Matrix<float, 3, 4> camera_to_world_end, const Eigen::Vector4f& rolling_shutter, bool convert_to_ngp = true);
-			void set_camera_extrinsics(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world, bool convert_to_ngp = true);
-			Eigen::Matrix<float, 3, 4> get_camera_extrinsics(int frame_idx);
+			void set_camera_extrinsics_rolling_shutter(int frame_idx, mat4x3 camera_to_world_start, mat4x3 camera_to_world_end, const vec4& rolling_shutter, bool convert_to_ngp = true);
+			void set_camera_extrinsics(int frame_idx, mat4x3 camera_to_world, bool convert_to_ngp = true);
+			mat4x3 get_camera_extrinsics(int frame_idx);
 			void update_transforms(int first = 0, int last = -1);
+			void update_extra_dims();
 
 #ifdef NGP_PYTHON
 			void set_image(int frame_idx, pybind11::array_t<float> img, pybind11::array_t<float> depth_img, float depth_scale);
@@ -741,7 +742,7 @@ public:
 		ENerfActivation rgb_activation = ENerfActivation::Exponential;
 		ENerfActivation density_activation = ENerfActivation::Exponential;
 
-		Eigen::Vector3f light_dir = Eigen::Vector3f::Constant(0.5f);
+		vec3 light_dir = vec3(0.5f);
 		uint32_t extra_dim_idx_for_inference = 0; // which training image's latent code should be presented at inference time
 
 		int show_accel = -1;
@@ -758,6 +759,7 @@ public:
 
 		float glow_y_cutoff = 0.f;
 		int glow_mode = 0;
+
 	} m_nerf;
 
 	struct Sdf {
@@ -806,11 +808,11 @@ public:
 			bool did_generate_more_training_data = false;
 			bool generate_sdf_data_online = true;
 			float surface_offset_scale = 1.0f;
-			tcnn::GPUMemory<Eigen::Vector3f> positions;
-			tcnn::GPUMemory<Eigen::Vector3f> positions_shuffled;
+			tcnn::GPUMemory<vec3> positions;
+			tcnn::GPUMemory<vec3> positions_shuffled;
 			tcnn::GPUMemory<float> distances;
 			tcnn::GPUMemory<float> distances_shuffled;
-			tcnn::GPUMemory<Eigen::Vector3f> perturbations;
+			tcnn::GPUMemory<vec3> perturbations;
 		} training = {};
 	} m_sdf;
 
@@ -823,15 +825,15 @@ public:
 		tcnn::GPUMemory<char> data;
 
 		EDataType type = EDataType::Float;
-		Eigen::Vector2i resolution = Eigen::Vector2i::Constant(0.0f);
+		ivec2 resolution = ivec2(0);
 
-		tcnn::GPUMemory<Eigen::Vector2f> render_coords;
-		tcnn::GPUMemory<Eigen::Array3f> render_out;
+		tcnn::GPUMemory<vec2> render_coords;
+		tcnn::GPUMemory<vec3> render_out;
 
 		struct Training {
 			tcnn::GPUMemory<float> positions_tmp;
-			tcnn::GPUMemory<Eigen::Vector2f> positions;
-			tcnn::GPUMemory<Eigen::Array3f> targets;
+			tcnn::GPUMemory<vec2> positions;
+			tcnn::GPUMemory<vec3> targets;
 
 			bool snap_to_pixel_centers = true;
 			bool linear_colors = false;
@@ -841,8 +843,8 @@ public:
 	} m_image;
 
 	struct VolPayload {
-		Eigen::Vector3f dir;
-		Eigen::Array4f col;
+		vec3 dir;
+		vec4 col;
 		uint32_t pixidx;
 	};
 
@@ -853,19 +855,19 @@ public:
 		tcnn::GPUMemory<char> nanovdb_grid;
 		tcnn::GPUMemory<uint8_t> bitgrid;
 		float global_majorant = 1.f;
-		Eigen::Vector3f world2index_offset = {0, 0, 0};
+		vec3 world2index_offset = {0, 0, 0};
 		float world2index_scale = 1.f;
 
 		struct Training {
-			tcnn::GPUMemory<Eigen::Vector3f> positions = {};
-			tcnn::GPUMemory<Eigen::Array4f> targets = {};
+			tcnn::GPUMemory<vec3> positions = {};
+			tcnn::GPUMemory<vec4> targets = {};
 		} training = {};
 
 		// tracing state
-		tcnn::GPUMemory<Eigen::Vector3f> pos[2] = {};
+		tcnn::GPUMemory<vec3> pos[2] = {};
 		tcnn::GPUMemory<VolPayload> payload[2] = {};
 		tcnn::GPUMemory<uint32_t> hit_counter = {};
-		tcnn::GPUMemory<Eigen::Array4f> radiance_and_density;
+		tcnn::GPUMemory<vec4> radiance_and_density;
 	} m_volume;
 
 	float m_camera_velocity = 1.0f;
@@ -879,15 +881,15 @@ public:
 	float m_render_near_distance = 0.0f;
 	float m_slice_plane_z = 0.0f;
 	bool m_floor_enable = false;
-	inline float get_floor_y() const { return m_floor_enable ? m_aabb.min.y() + 0.001f : -10000.f; }
+	inline float get_floor_y() const { return m_floor_enable ? m_aabb.min.y + 0.001f : -10000.f; }
 	BoundingBox m_raw_aabb;
 	BoundingBox m_aabb;
 	BoundingBox m_render_aabb;
-	Eigen::Matrix3f m_render_aabb_to_local;
+	mat3 m_render_aabb_to_local = mat3(1.0f);
 
-	Eigen::Matrix<float, 3, 4> crop_box(bool nerf_space) const;
-	std::vector<Eigen::Vector3f> crop_box_corners(bool nerf_space) const;
-	void set_crop_box(Eigen::Matrix<float, 3, 4> m, bool nerf_space);
+	mat4x3 crop_box(bool nerf_space) const;
+	std::vector<vec3> crop_box_corners(bool nerf_space) const;
+	void set_crop_box(mat4x3 m, bool nerf_space);
 
 	// Rendering/UI bookkeeping
 	Ema m_training_prep_ms = {EEmaType::Time, 100};
@@ -898,7 +900,7 @@ public:
 	std::chrono::time_point<std::chrono::steady_clock> m_last_frame_time_point;
 	std::chrono::time_point<std::chrono::steady_clock> m_last_gui_draw_time_point;
 	std::chrono::time_point<std::chrono::steady_clock> m_training_start_time_point;
-	Eigen::Array4f m_background_color = {0.0f, 0.0f, 0.0f, 1.0f};
+	vec4 m_background_color = {0.0f, 0.0f, 0.0f, 1.0f};
 
 	bool m_vsync = false;
 	bool m_render_transparency_as_checkerboard = false;
@@ -909,24 +911,24 @@ public:
 
 	struct View {
 		std::shared_ptr<CudaRenderBuffer> render_buffer;
-		Eigen::Vector2i full_resolution = {1, 1};
+		ivec2 full_resolution = {1, 1};
 		int visualized_dimension = 0;
 
-		Eigen::Matrix<float, 3, 4> camera0 = Eigen::Matrix<float, 3, 4>::Zero();
-		Eigen::Matrix<float, 3, 4> camera1 = Eigen::Matrix<float, 3, 4>::Zero();
-		Eigen::Matrix<float, 3, 4> prev_camera = Eigen::Matrix<float, 3, 4>::Zero();
+		mat4x3 camera0 = mat4x3(1.0f);
+		mat4x3 camera1 = mat4x3(1.0f);
+		mat4x3 prev_camera = mat4x3(1.0f);
 
 		Foveation foveation;
 		Foveation prev_foveation;
 
-		Eigen::Vector2f relative_focal_length;
-		Eigen::Vector2f screen_center;
+		vec2 relative_focal_length;
+		vec2 screen_center;
 
 		CudaDevice* device = nullptr;
 	};
 
 	std::vector<View> m_views;
-	Eigen::Vector2i m_n_views = {1, 1};
+	ivec2 m_n_views = {1, 1};
 
 	bool m_single_view = true;
 
@@ -951,7 +953,7 @@ public:
 
 	bool m_snap_to_pixel_centers = false;
 
-	Eigen::Vector3f m_parallax_shift = {0.0f, 0.0f, 0.0f}; // to shift the viewer's origin by some amount in camera space
+	vec3 m_parallax_shift = {0.0f, 0.0f, 0.0f}; // to shift the viewer's origin by some amount in camera space
 
 	// CUDA stuff
 	tcnn::StreamAndEvent m_stream;
@@ -960,7 +962,8 @@ public:
 	float m_quant_percent = 0.f;
 	std::vector<LevelStats> m_level_stats;
 	std::vector<LevelStats> m_first_layer_column_stats;
-	int m_num_levels = 0;
+	int m_n_levels = 0;
+	uint32_t m_n_features_per_level = 0;
 	int m_histo_level = 0; // collect a histogram for this level
 	uint32_t m_base_grid_resolution;
 	float m_per_level_scale;
@@ -1171,23 +1174,23 @@ public:
 		std::shared_ptr<TrainableBuffer<4, 2, float>> envmap;
 		std::shared_ptr<tcnn::Trainer<float, float, float>> trainer;
 
-		Eigen::Vector2i resolution;
+		ivec2 resolution;
 		ELossType loss_type;
 
-		Buffer2DView<const Eigen::Array4f> inference_view() const {
+		Buffer2DView<const vec4> inference_view() const {
 			if (!envmap) {
 				return {};
 			}
 
-			return {(const Eigen::Array4f*)envmap->inference_params(), resolution};
+			return {(const vec4*)envmap->inference_params(), resolution};
 		}
 
-		Buffer2DView<const Eigen::Array4f> view() const {
+		Buffer2DView<const vec4> view() const {
 			if (!envmap) {
 				return {};
 			}
 
-			return {(const Eigen::Array4f*)envmap->params(), resolution};
+			return {(const vec4*)envmap->params(), resolution};
 		}
 	} m_envmap;
 
@@ -1195,22 +1198,22 @@ public:
 		std::shared_ptr<tcnn::Optimizer<float>> optimizer;
 		std::shared_ptr<TrainableBuffer<2, 2, float>> map;
 		std::shared_ptr<tcnn::Trainer<float, float, float>> trainer;
-		Eigen::Vector2i resolution;
+		ivec2 resolution;
 
-		Buffer2DView<const Eigen::Vector2f> inference_view() const {
+		Buffer2DView<const vec2> inference_view() const {
 			if (!map) {
 				return {};
 			}
 
-			return {(const Eigen::Vector2f*)map->inference_params(), resolution};
+			return {(const vec2*)map->inference_params(), resolution};
 		}
 
-		Buffer2DView<const Eigen::Vector2f> view() const {
+		Buffer2DView<const vec2> view() const {
 			if (!map) {
 				return {};
 			}
 
-			return {(const Eigen::Vector2f*)map->params(), resolution};
+			return {(const vec2*)map->params(), resolution};
 		}
 	} m_distortion;
 	std::shared_ptr<NerfNetwork<precision_t>> m_nerf_network;

--- a/include/neural-graphics-primitives/tinyobj_loader_wrapper.h
+++ b/include/neural-graphics-primitives/tinyobj_loader_wrapper.h
@@ -23,6 +23,6 @@
 
 NGP_NAMESPACE_BEGIN
 
-std::vector<Eigen::Vector3f> load_obj(const fs::path& path);
+std::vector<vec3> load_obj(const fs::path& path);
 
 NGP_NAMESPACE_END

--- a/include/neural-graphics-primitives/trainable_buffer.cuh
+++ b/include/neural-graphics-primitives/trainable_buffer.cuh
@@ -28,10 +28,12 @@ NGP_NAMESPACE_BEGIN
 
 template <uint32_t N_DIMS, uint32_t RANK, typename T>
 class TrainableBuffer : public tcnn::DifferentiableObject<float, T, T> {
-	using ResVector = Eigen::Matrix<int, RANK, 1>;
-
 public:
-	TrainableBuffer(const ResVector& resolution) : m_resolution{resolution} {
+	template <typename RES>
+	TrainableBuffer(const RES& resolution) {
+		for (uint32_t i = 0; i < RANK; ++i) {
+			m_resolution[i] = resolution[i];
+		}
 		m_params_gradient_weight.resize(n_params());
 	}
 
@@ -66,7 +68,11 @@ public:
 	}
 
 	size_t n_params() const override {
-		return m_resolution.prod() * N_DIMS;
+		size_t result = N_DIMS;
+		for (uint32_t i = 0; i < RANK; ++i) {
+			result *= m_resolution[i];
+		}
+		return result;
 	}
 
 	uint32_t input_width() const override {
@@ -100,7 +106,7 @@ public:
 	}
 
 private:
-	ResVector m_resolution;
+	uint32_t m_resolution[RANK];
 	tcnn::GPUMemory<T> m_params_gradient_weight;
 };
 

--- a/include/neural-graphics-primitives/triangle.cuh
+++ b/include/neural-graphics-primitives/triangle.cuh
@@ -23,77 +23,77 @@
 NGP_NAMESPACE_BEGIN
 
 struct Triangle {
-	NGP_HOST_DEVICE Eigen::Vector3f sample_uniform_position(const Eigen::Vector2f& sample) const {
-		float sqrt_x = std::sqrt(sample.x());
+	NGP_HOST_DEVICE vec3 sample_uniform_position(const vec2& sample) const {
+		float sqrt_x = std::sqrt(sample.x);
 		float factor0 = 1.0f - sqrt_x;
-		float factor1 = sqrt_x * (1.0f - sample.y());
-		float factor2 = sqrt_x * sample.y();
+		float factor1 = sqrt_x * (1.0f - sample.y);
+		float factor2 = sqrt_x * sample.y;
 
 		return factor0 * a + factor1 * b + factor2 * c;
 	}
 
 	NGP_HOST_DEVICE float surface_area() const {
-		return 0.5f * Eigen::Vector3f((b - a).cross(c - a)).norm();
+		return 0.5f * length(cross(b - a, c - a));
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f normal() const {
-		return (b - a).cross(c - a).normalized();
+	NGP_HOST_DEVICE vec3 normal() const {
+		return normalize(cross(b - a, c - a));
 	}
 
 	// based on https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
-	NGP_HOST_DEVICE float ray_intersect(const Eigen::Vector3f &ro, const Eigen::Vector3f &rd, Eigen::Vector3f& n) const {
-		Eigen::Vector3f v1v0 = b - a;
-		Eigen::Vector3f v2v0 = c - a;
-		Eigen::Vector3f rov0 = ro - a;
-		n = v1v0.cross(v2v0);
-		Eigen::Vector3f q = rov0.cross(rd);
-		float d = 1.0f / rd.dot(n);
-		float u = d * -q.dot(v2v0);
-		float v = d *  q.dot(v1v0);
-		float t = d * -n.dot(rov0);
+	NGP_HOST_DEVICE float ray_intersect(const vec3 &ro, const vec3 &rd, vec3& n) const {
+		vec3 v1v0 = b - a;
+		vec3 v2v0 = c - a;
+		vec3 rov0 = ro - a;
+		n = cross(v1v0, v2v0);
+		vec3 q = cross(rov0, rd);
+		float d = 1.0f / dot(rd, n);
+		float u = d * -dot(q, v2v0);
+		float v = d *  dot(q, v1v0);
+		float t = d * -dot(n, rov0);
 		if (u < 0.0f || u > 1.0f || v < 0.0f || (u+v) > 1.0f || t < 0.0f) {
 			t = std::numeric_limits<float>::max(); // No intersection
 		}
 		return t;
 	}
 
-	NGP_HOST_DEVICE float ray_intersect(const Eigen::Vector3f &ro, const Eigen::Vector3f &rd) const {
-		Eigen::Vector3f n;
+	NGP_HOST_DEVICE float ray_intersect(const vec3 &ro, const vec3 &rd) const {
+		vec3 n;
 		return ray_intersect(ro, rd, n);
 	}
 
 	// based on https://www.iquilezles.org/www/articles/distfunctions/distfunctions.htm
-	NGP_HOST_DEVICE float distance_sq(const Eigen::Vector3f& pos) const {
-		Eigen::Vector3f v21 = b - a; Eigen::Vector3f p1 = pos - a;
-		Eigen::Vector3f v32 = c - b; Eigen::Vector3f p2 = pos - b;
-		Eigen::Vector3f v13 = a - c; Eigen::Vector3f p3 = pos - c;
-		Eigen::Vector3f nor = v21.cross(v13);
+	NGP_HOST_DEVICE float distance_sq(const vec3& pos) const {
+		vec3 v21 = b - a; vec3 p1 = pos - a;
+		vec3 v32 = c - b; vec3 p2 = pos - b;
+		vec3 v13 = a - c; vec3 p3 = pos - c;
+		vec3 nor = cross(v21, v13);
 
 		return
 			// inside/outside test
-			(sign(v21.cross(nor).dot(p1)) + sign(v32.cross(nor).dot(p2)) + sign(v13.cross(nor).dot(p3)) < 2.0f)
+			(sign(dot(cross(v21, nor), p1)) + sign(dot(cross(v32, nor), p2)) + sign(dot(cross(v13, nor), p3)) < 2.0f)
 			?
 			// 3 edges
 			std::min({
-				(v21 * tcnn::clamp(v21.dot(p1) / v21.squaredNorm(), 0.0f, 1.0f)-p1).squaredNorm(),
-				(v32 * tcnn::clamp(v32.dot(p2) / v32.squaredNorm(), 0.0f, 1.0f)-p2).squaredNorm(),
-				(v13 * tcnn::clamp(v13.dot(p3) / v13.squaredNorm(), 0.0f, 1.0f)-p3).squaredNorm(),
+				length2(v21 * tcnn::clamp(dot(v21, p1) / length2(v21), 0.0f, 1.0f)-p1),
+				length2(v32 * tcnn::clamp(dot(v32, p2) / length2(v32), 0.0f, 1.0f)-p2),
+				length2(v13 * tcnn::clamp(dot(v13, p3) / length2(v13), 0.0f, 1.0f)-p3),
 			})
 			:
 			// 1 face
-			nor.dot(p1)*nor.dot(p1)/nor.squaredNorm();
+			dot(nor, p1) * dot(nor, p1) / length2(nor);
 	}
 
-	NGP_HOST_DEVICE float distance(const Eigen::Vector3f& pos) const {
+	NGP_HOST_DEVICE float distance(const vec3& pos) const {
 		return std::sqrt(distance_sq(pos));
 	}
 
-	NGP_HOST_DEVICE bool point_in_triangle(const Eigen::Vector3f& p) const {
+	NGP_HOST_DEVICE bool point_in_triangle(const vec3& p) const {
 		// Move the triangle so that the point becomes the
 		// triangles origin
-		Eigen::Vector3f local_a = a - p;
-		Eigen::Vector3f local_b = b - p;
-		Eigen::Vector3f local_c = c - p;
+		vec3 local_a = a - p;
+		vec3 local_b = b - p;
+		vec3 local_c = c - p;
 
 		// The point should be moved too, so they are both
 		// relative, but because we don't use p in the
@@ -105,35 +105,35 @@ struct Triangle {
 		// v = normal of PCA
 		// w = normal of PAB
 
-		Eigen::Vector3f u = local_b.cross(local_c);
-		Eigen::Vector3f v = local_c.cross(local_a);
-		Eigen::Vector3f w = local_a.cross(local_b);
+		vec3 u = cross(local_b, local_c);
+		vec3 v = cross(local_c, local_a);
+		vec3 w = cross(local_a, local_b);
 
 		// Test to see if the normals are facing the same direction.
 		// If yes, the point is inside, otherwise it isn't.
-		return u.dot(v) >= 0.0f && u.dot(w) >= 0.0f;
+		return dot(u, v) >= 0.0f && dot(u, w) >= 0.0f;
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f closest_point_to_line(const Eigen::Vector3f& a, const Eigen::Vector3f& b, const Eigen::Vector3f& c) const {
-		float t = (c - a).dot(b-a) / (b-a).dot(b-a);
+	NGP_HOST_DEVICE vec3 closest_point_to_line(const vec3& a, const vec3& b, const vec3& c) const {
+		float t = dot(c - a, b - a) / dot(b - a, b - a);
 		t = std::max(std::min(t, 1.0f), 0.0f);
 		return a + t * (b - a);
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f closest_point(Eigen::Vector3f point) const {
-		point -= normal().dot(point - a) * normal();
+	NGP_HOST_DEVICE vec3 closest_point(vec3 point) const {
+		point -= dot(normal(), point - a) * normal();
 
 		if (point_in_triangle(point)) {
 			return point;
 		}
 
-		Eigen::Vector3f c1 = closest_point_to_line(a, b, point);
-		Eigen::Vector3f c2 = closest_point_to_line(b, c, point);
-		Eigen::Vector3f c3 = closest_point_to_line(c, a, point);
+		vec3 c1 = closest_point_to_line(a, b, point);
+		vec3 c2 = closest_point_to_line(b, c, point);
+		vec3 c3 = closest_point_to_line(c, a, point);
 
-		float mag1 = (point - c1).squaredNorm();
-		float mag2 = (point - c2).squaredNorm();
-		float mag3 = (point - c3).squaredNorm();
+		float mag1 = length2(point - c1);
+		float mag2 = length2(point - c2);
+		float mag3 = length2(point - c3);
 
 		float min = std::min({mag1, mag2, mag3});
 
@@ -146,7 +146,7 @@ struct Triangle {
 		}
 	}
 
-	NGP_HOST_DEVICE Eigen::Vector3f centroid() const {
+	NGP_HOST_DEVICE vec3 centroid() const {
 		return (a + b + c) / 3.0f;
 	}
 
@@ -154,20 +154,20 @@ struct Triangle {
 		return (a[axis] + b[axis] + c[axis]) / 3;
 	}
 
-	NGP_HOST_DEVICE void get_vertices(Eigen::Vector3f v[3]) const {
+	NGP_HOST_DEVICE void get_vertices(vec3 v[3]) const {
 		v[0] = a;
 		v[1] = b;
 		v[2] = c;
 	}
 
-	Eigen::Vector3f a, b, c;
+	vec3 a, b, c;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const ngp::Triangle& triangle) {
 	os << "[";
-	os << "a=[" << triangle.a.x() << "," << triangle.a.y() << "," << triangle.a.z() << "], ";
-	os << "b=[" << triangle.b.x() << "," << triangle.b.y() << "," << triangle.b.z() << "], ";
-	os << "c=[" << triangle.c.x() << "," << triangle.c.y() << "," << triangle.c.z() << "]";
+	os << "a=[" << triangle.a.x << "," << triangle.a.y << "," << triangle.a.z << "], ";
+	os << "b=[" << triangle.b.x << "," << triangle.b.y << "," << triangle.b.z << "], ";
+	os << "c=[" << triangle.c.x << "," << triangle.c.y << "," << triangle.c.z << "]";
 	os << "]";
 	return os;
 }

--- a/include/neural-graphics-primitives/triangle_bvh.cuh
+++ b/include/neural-graphics-primitives/triangle_bvh.cuh
@@ -57,12 +57,12 @@ private:
 using FixedIntStack = FixedStack<int>;
 
 
-__host__ __device__ std::pair<int, float> trianglebvh_ray_intersect(const Eigen::Vector3f& ro, const Eigen::Vector3f& rd, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles);
+__host__ __device__ std::pair<int, float> trianglebvh_ray_intersect(const vec3& ro, const vec3& rd, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles);
 
 class TriangleBvh {
 public:
-	virtual void signed_distance_gpu(uint32_t n_elements, EMeshSdfMode mode, const Eigen::Vector3f* gpu_positions, float* gpu_distances, const Triangle* gpu_triangles, bool use_existing_distances_as_upper_bounds, cudaStream_t stream) = 0;
-	virtual void ray_trace_gpu(uint32_t n_elements, Eigen::Vector3f* gpu_positions, Eigen::Vector3f* gpu_directions, const Triangle* gpu_triangles, cudaStream_t stream) = 0;
+	virtual void signed_distance_gpu(uint32_t n_elements, EMeshSdfMode mode, const vec3* gpu_positions, float* gpu_distances, const Triangle* gpu_triangles, bool use_existing_distances_as_upper_bounds, cudaStream_t stream) = 0;
+	virtual void ray_trace_gpu(uint32_t n_elements, vec3* gpu_positions, vec3* gpu_directions, const Triangle* gpu_triangles, cudaStream_t stream) = 0;
 	virtual bool touches_triangle(const BoundingBox& bb, const Triangle* __restrict__ triangles) const = 0;
 	virtual void build(std::vector<Triangle>& triangles, uint32_t n_primitives_per_leaf) = 0;
 	virtual void build_optix(const tcnn::GPUMemory<Triangle>& triangles, cudaStream_t stream) = 0;

--- a/scripts/colmap2nerf.py
+++ b/scripts/colmap2nerf.py
@@ -37,7 +37,7 @@ def parse_args():
 	parser.add_argument("--colmap_camera_params", default="", help="Intrinsic parameters, depending on the chosen model. Format: fx,fy,cx,cy,dist")
 	parser.add_argument("--images", default="images", help="Input path to the images.")
 	parser.add_argument("--text", default="colmap_text", help="Input path to the colmap text files (set automatically if --run_colmap is used).")
-	parser.add_argument("--aabb_scale", default=64, choices=["1", "2", "4", "8", "16", "32", "64", "128"], help="Large scene scale factor. 1=scene fits in unit cube; power of 2 up to 128")
+	parser.add_argument("--aabb_scale", default=32, choices=["1", "2", "4", "8", "16", "32", "64", "128"], help="Large scene scale factor. 1=scene fits in unit cube; power of 2 up to 128")
 	parser.add_argument("--skip_early", default=0, help="Skip this many images from the start.")
 	parser.add_argument("--keep_colmap_coords", action="store_true", help="Keep transforms.json in COLMAP's original frame of reference (this will avoid reorienting and repositioning the scene for preview and rendering).")
 	parser.add_argument("--out", default="transforms.json", help="Output path.")

--- a/src/common_device.cu
+++ b/src/common_device.cu
@@ -15,25 +15,23 @@
 #include <neural-graphics-primitives/common_device.cuh>
 #include <neural-graphics-primitives/tinyexr_wrapper.h>
 
-#include <unsupported/Eigen/MatrixFunctions>
+// #include <unsupported/Eigen/MatrixFunctions>
 
 #include <stb_image/stb_image.h>
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
 
 
-Matrix<float, 3, 4> log_space_lerp(const Matrix<float, 3, 4>& begin, const Matrix<float, 3, 4>& end, float t) {
-	Matrix4f A = Matrix4f::Identity();
-	A.block<3,4>(0,0) = begin;
-	Matrix4f B = Matrix4f::Identity();
-	B.block<3,4>(0,0) = end;
+mat4x3 camera_lerp(const mat4x3& a, const mat4x3& b, float t) {
+	// mat4 A = a;
+	// mat4 B = b;
+	// mat4 log_space_a_to_b = log(B * inverse(A));
+	// return exp(log_space_a_to_b * t) * A;
 
-	Matrix4f log_space_a_to_b = (B * A.inverse()).log();
-
-	return ((log_space_a_to_b * t).exp() * A).block<3,4>(0,0);
+	mat3 rot = slerp(a, b, t);
+	return {rot[0], rot[1], rot[2], mix(a[3], b[3], t)};
 }
 
 GPUMemory<float> load_exr_gpu(const fs::path& path, int* width, int* height) {

--- a/src/dlss.cu
+++ b/src/dlss.cu
@@ -47,10 +47,10 @@ static_assert(false, "DLSS can only be compiled when both Vulkan and GUI support
 #include <nvsdk_ngx_helpers.h>
 #include <nvsdk_ngx_helpers_vk.h>
 
+#include <atomic>
 #include <codecvt>
 #include <locale>
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
@@ -583,7 +583,7 @@ public:
 		return allocated_bytes;
 	}
 
-	std::unique_ptr<IDlss> init_dlss(const Eigen::Vector2i& out_resolution) override;
+	std::unique_ptr<IDlss> init_dlss(const ivec2& out_resolution) override;
 
 private:
 	VkInstance m_vk_instance = VK_NULL_HANDLE;
@@ -603,14 +603,14 @@ std::shared_ptr<IDlssProvider> init_vulkan_and_ngx() {
 
 class VulkanTexture {
 public:
-	VulkanTexture(std::shared_ptr<VulkanAndNgx> vk, const Vector2i& size, uint32_t n_channels) : m_vk{vk}, m_size{size}, m_n_channels{n_channels} {
+	VulkanTexture(std::shared_ptr<VulkanAndNgx> vk, const ivec2& size, uint32_t n_channels) : m_vk{vk}, m_size{size}, m_n_channels{n_channels} {
 		ScopeGuard cleanup_guard{[&]() { clear(); }};
 
 		VkImageCreateInfo image_info{};
 		image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
 		image_info.imageType = VK_IMAGE_TYPE_2D;
-		image_info.extent.width = static_cast<uint32_t>(m_size.x());
-		image_info.extent.height = static_cast<uint32_t>(m_size.y());
+		image_info.extent.width = static_cast<uint32_t>(m_size.x);
+		image_info.extent.height = static_cast<uint32_t>(m_size.y);
 		image_info.extent.depth = 1;
 		image_info.mipLevels = 1;
 		image_info.arrayLayers = 1;
@@ -701,7 +701,7 @@ public:
 		VK_CHECK_THROW(vkCreateImageView(m_vk->vk_device(), &view_info, nullptr, &m_vk_image_view));
 
 		// Map to NGX
-		m_ngx_resource = NVSDK_NGX_Create_ImageView_Resource_VK(m_vk_image_view, m_vk_image, view_info.subresourceRange, image_info.format, m_size.x(), m_size.y(), true);
+		m_ngx_resource = NVSDK_NGX_Create_ImageView_Resource_VK(m_vk_image_view, m_vk_image, view_info.subresourceRange, image_info.format, m_size.x, m_size.y, true);
 
 		// Map to CUDA memory: VkDeviceMemory->FD/HANDLE->cudaExternalMemory->CUDA pointer
 #ifdef _WIN32
@@ -767,8 +767,8 @@ public:
 		}
 
 		cudaExtent extent = {};
-		extent.width = m_size.x();
-		extent.height = m_size.y();
+		extent.width = m_size.x;
+		extent.height = m_size.y;
 		extent.depth = 0;
 
 		external_memory_mipmapped_array_desc.offset = 0;
@@ -851,17 +851,17 @@ public:
 	}
 
 	size_t bytes() const {
-		return m_size.x() * (size_t)m_size.y() * sizeof(float) * m_n_channels;
+		return m_size.x * (size_t)m_size.y * sizeof(float) * m_n_channels;
 	}
 
-	Vector2i size() const {
+	ivec2 size() const {
 		return m_size;
 	}
 
 private:
 	std::shared_ptr<VulkanAndNgx> m_vk;
 
-	Vector2i m_size;
+	ivec2 m_size;
 	uint32_t m_n_channels;
 
 	size_t m_n_bytes = 0;
@@ -891,40 +891,40 @@ NVSDK_NGX_PerfQuality_Value ngx_dlss_quality(EDlssQuality quality) {
 
 struct DlssFeatureSpecs {
 	EDlssQuality quality;
-	Vector2i out_resolution;
-	Vector2i optimal_in_resolution;
-	Vector2i min_in_resolution;
-	Vector2i max_in_resolution;
+	ivec2 out_resolution;
+	ivec2 optimal_in_resolution;
+	ivec2 min_in_resolution;
+	ivec2 max_in_resolution;
 	float optimal_sharpness;
 
-	float distance(const Vector2i& resolution) const {
-		return (min_in_resolution - resolution).cwiseMax(resolution - max_in_resolution).cwiseMax(0).cast<float>().norm();
+	float distance(const ivec2& resolution) const {
+		return length(vec2(max(max(min_in_resolution - resolution, resolution - max_in_resolution), ivec2(0))));
 	}
 
-	Vector2i clamp_resolution(const Vector2i& resolution) const {
-		return resolution.cwiseMax(min_in_resolution).cwiseMin(max_in_resolution);
+	ivec2 clamp_resolution(const ivec2& resolution) const {
+		return clamp(resolution, min_in_resolution, max_in_resolution);
 	}
 };
 
-DlssFeatureSpecs dlss_feature_specs(NVSDK_NGX_Parameter* ngx_parameters, const Eigen::Vector2i& out_resolution, EDlssQuality quality) {
+DlssFeatureSpecs dlss_feature_specs(NVSDK_NGX_Parameter* ngx_parameters, const ivec2& out_resolution, EDlssQuality quality) {
 	DlssFeatureSpecs specs;
 	specs.quality = quality;
 	specs.out_resolution = out_resolution;
 
 	NGX_CHECK_THROW(NGX_DLSS_GET_OPTIMAL_SETTINGS(
 		ngx_parameters,
-		specs.out_resolution.x(), specs.out_resolution.y(),
+		specs.out_resolution.x, specs.out_resolution.y,
 		ngx_dlss_quality(quality),
-		(uint32_t*)&specs.optimal_in_resolution.x(), (uint32_t*)&specs.optimal_in_resolution.y(),
-		(uint32_t*)&specs.max_in_resolution.x(), (uint32_t*)&specs.max_in_resolution.y(),
-		(uint32_t*)&specs.min_in_resolution.x(), (uint32_t*)&specs.min_in_resolution.y(),
+		(uint32_t*)&specs.optimal_in_resolution.x, (uint32_t*)&specs.optimal_in_resolution.y,
+		(uint32_t*)&specs.max_in_resolution.x, (uint32_t*)&specs.max_in_resolution.y,
+		(uint32_t*)&specs.min_in_resolution.x, (uint32_t*)&specs.min_in_resolution.y,
 		&specs.optimal_sharpness
 	));
 
 	// Don't permit input resolutions larger than the output. (Just in case DLSS allows it.)
-	specs.optimal_in_resolution = specs.optimal_in_resolution.cwiseMin(out_resolution);
-	specs.max_in_resolution = specs.max_in_resolution.cwiseMin(out_resolution);
-	specs.min_in_resolution = specs.min_in_resolution.cwiseMin(out_resolution);
+	specs.optimal_in_resolution = min(specs.optimal_in_resolution, out_resolution);
+	specs.max_in_resolution = min(specs.max_in_resolution, out_resolution);
+	specs.min_in_resolution = min(specs.min_in_resolution, out_resolution);
 
 	return specs;
 }
@@ -948,10 +948,10 @@ public:
 
 		memset(&dlss_create_params, 0, sizeof(dlss_create_params));
 
-		dlss_create_params.Feature.InWidth = m_specs.optimal_in_resolution.x();
-		dlss_create_params.Feature.InHeight = m_specs.optimal_in_resolution.y();
-		dlss_create_params.Feature.InTargetWidth = m_specs.out_resolution.x();
-		dlss_create_params.Feature.InTargetHeight = m_specs.out_resolution.y();
+		dlss_create_params.Feature.InWidth = m_specs.optimal_in_resolution.x;
+		dlss_create_params.Feature.InHeight = m_specs.optimal_in_resolution.y;
+		dlss_create_params.Feature.InTargetWidth = m_specs.out_resolution.x;
+		dlss_create_params.Feature.InTargetHeight = m_specs.out_resolution.y;
 		dlss_create_params.Feature.InPerfQualityValue = ngx_dlss_quality(m_specs.quality);
 		dlss_create_params.InFeatureCreateFlags = dlss_create_feature_flags;
 
@@ -963,7 +963,7 @@ public:
 		}
 	}
 
-	DlssFeature(std::shared_ptr<VulkanAndNgx> vk_and_ngx, const Eigen::Vector2i& out_resolution, bool is_hdr, bool sharpen, EDlssQuality quality)
+	DlssFeature(std::shared_ptr<VulkanAndNgx> vk_and_ngx, const ivec2& out_resolution, bool is_hdr, bool sharpen, EDlssQuality quality)
 	: DlssFeature{vk_and_ngx, dlss_feature_specs(vk_and_ngx->ngx_parameters(), out_resolution, quality), is_hdr, sharpen} {}
 
 	~DlssFeature() {
@@ -977,8 +977,8 @@ public:
 	}
 
 	void run(
-		const Vector2i& in_resolution,
-		const Vector2f& jitter_offset,
+		const ivec2& in_resolution,
+		const vec2& jitter_offset,
 		float sharpening,
 		bool shall_reset,
 		NVSDK_NGX_Resource_VK& frame,
@@ -1001,13 +1001,13 @@ public:
 		dlss_params.pInDepth = &depth;
 		dlss_params.pInMotionVectors = &mvec;
 		dlss_params.pInExposureTexture = &exposure;
-		dlss_params.InJitterOffsetX = jitter_offset.x();
-		dlss_params.InJitterOffsetY = jitter_offset.y();
+		dlss_params.InJitterOffsetX = jitter_offset.x;
+		dlss_params.InJitterOffsetY = jitter_offset.y;
 		dlss_params.Feature.InSharpness = sharpening;
 		dlss_params.InReset = shall_reset;
 		dlss_params.InMVScaleX = 1.0f;
 		dlss_params.InMVScaleY = 1.0f;
-		dlss_params.InRenderSubrectDimensions = {(uint32_t)in_resolution.x(), (uint32_t)in_resolution.y()};
+		dlss_params.InRenderSubrectDimensions = {(uint32_t)in_resolution.x, (uint32_t)in_resolution.y};
 
 		NGX_CHECK_THROW(NGX_VULKAN_EVALUATE_DLSS_EXT(m_vk_and_ngx->vk_command_buffer(), m_ngx_dlss, m_vk_and_ngx->ngx_parameters(), &dlss_params));
 
@@ -1026,15 +1026,15 @@ public:
 		return m_specs.quality;
 	}
 
-	Vector2i out_resolution() const {
+	ivec2 out_resolution() const {
 		return m_specs.out_resolution;
 	}
 
-	Vector2i clamp_resolution(const Vector2i& resolution) const {
+	ivec2 clamp_resolution(const ivec2& resolution) const {
 		return m_specs.clamp_resolution(resolution);
 	}
 
-	Vector2i optimal_in_resolution() const {
+	ivec2 optimal_in_resolution() const {
 		return m_specs.optimal_in_resolution;
 	}
 
@@ -1049,7 +1049,7 @@ private:
 
 class Dlss : public IDlss {
 public:
-	Dlss(std::shared_ptr<VulkanAndNgx> vk_and_ngx, const Eigen::Vector2i& max_out_resolution)
+	Dlss(std::shared_ptr<VulkanAndNgx> vk_and_ngx, const ivec2& max_out_resolution)
 	:
 	m_vk_and_ngx{vk_and_ngx},
 	m_max_out_resolution{max_out_resolution},
@@ -1078,7 +1078,7 @@ public:
 
 		// For super insane performance requirements (more than 3x upscaling) try UltraPerformance
 		// with reduced output resolutions for 4.5x, 6x, 9x.
-		std::vector<Vector2i> reduced_out_resolutions = {
+		std::vector<ivec2> reduced_out_resolutions = {
 			max_out_resolution / 3 * 2,
 			max_out_resolution / 2,
 			max_out_resolution / 3,
@@ -1104,7 +1104,7 @@ public:
 		m_dlss_feature = nullptr;
 	}
 
-	void update_feature(const Vector2i& in_resolution, bool is_hdr, bool sharpen) override {
+	void update_feature(const ivec2& in_resolution, bool is_hdr, bool sharpen) override {
 		CUDA_CHECK_THROW(cudaDeviceSynchronize());
 
 		DlssFeatureSpecs specs;
@@ -1126,10 +1126,10 @@ public:
 	}
 
 	void run(
-		const Vector2i& in_resolution,
+		const ivec2& in_resolution,
 		bool is_hdr,
 		float sharpening,
-		const Vector2f& jitter_offset,
+		const vec2& jitter_offset,
 		bool shall_reset
 	) override {
 		CUDA_CHECK_THROW(cudaDeviceSynchronize());
@@ -1169,7 +1169,7 @@ public:
 		return m_output_buffer.surface();
 	}
 
-	Vector2i clamp_resolution(const Vector2i& resolution) const {
+	ivec2 clamp_resolution(const ivec2& resolution) const {
 		float min_distance = std::numeric_limits<float>::infinity();
 		DlssFeatureSpecs min_distance_specs = {};
 		for (const auto& specs : m_dlss_specs) {
@@ -1183,11 +1183,11 @@ public:
 		return min_distance_specs.clamp_resolution(resolution);
 	}
 
-	Vector2i out_resolution() const override {
+	ivec2 out_resolution() const override {
 		return m_dlss_feature ? m_dlss_feature->out_resolution() : m_max_out_resolution;
 	}
 
-	Vector2i max_out_resolution() const override {
+	ivec2 max_out_resolution() const override {
 		return m_max_out_resolution;
 	}
 
@@ -1215,10 +1215,10 @@ private:
 	VulkanTexture m_exposure_buffer;
 	VulkanTexture m_output_buffer;
 
-	Vector2i m_max_out_resolution;
+	ivec2 m_max_out_resolution;
 };
 
-std::unique_ptr<IDlss> VulkanAndNgx::init_dlss(const Eigen::Vector2i& out_resolution) {
+std::unique_ptr<IDlss> VulkanAndNgx::init_dlss(const ivec2& out_resolution) {
 	return std::make_unique<Dlss>(shared_from_this(), out_resolution);
 }
 

--- a/src/marching_cubes.cu
+++ b/src/marching_cubes.cu
@@ -35,17 +35,16 @@
 
 #include <vector>
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
 
-Vector3i get_marching_cubes_res(uint32_t res_1d, const BoundingBox &aabb) {
-	float scale = res_1d / (aabb.max - aabb.min).maxCoeff();
-	Vector3i res3d = ((aabb.max - aabb.min) * scale + Vector3f::Constant(0.5f)).cast<int>();
-	res3d.x() = next_multiple((unsigned int)res3d.x(), 16u);
-	res3d.y() = next_multiple((unsigned int)res3d.y(), 16u);
-	res3d.z() = next_multiple((unsigned int)res3d.z(), 16u);
+ivec3 get_marching_cubes_res(uint32_t res_1d, const BoundingBox &aabb) {
+	float scale = res_1d / compMax(aabb.max - aabb.min);
+	ivec3 res3d = (aabb.max - aabb.min) * scale + vec3(0.5f);
+	res3d.x = next_multiple((unsigned int)res3d.x, 16u);
+	res3d.y = next_multiple((unsigned int)res3d.y, 16u);
+	res3d.z = next_multiple((unsigned int)res3d.z, 16u);
 	return res3d;
 }
 
@@ -110,14 +109,14 @@ uint32_t compile_shader(bool pixel, const char* code) {
 }
 
 void draw_mesh_gl(
-	const GPUMemory<Vector3f>& verts,
-	const GPUMemory<Vector3f>& normals,
-	const GPUMemory<Vector3f>& colors,
+	const GPUMemory<vec3>& verts,
+	const GPUMemory<vec3>& normals,
+	const GPUMemory<vec3>& colors,
 	const GPUMemory<uint32_t>& indices,
-	const Vector2i& resolution,
-	const Vector2f& focal_length,
-	const Matrix<float, 3, 4>& camera_matrix,
-	const Vector2f& screen_center,
+	const ivec2& resolution,
+	const vec2& focal_length,
+	const mat4x3& camera_matrix,
+	const vec2& screen_center,
 	int mesh_render_mode
 ) {
 	if (verts.size() == 0 || indices.size() == 0 || mesh_render_mode == 0) {
@@ -138,7 +137,7 @@ void draw_mesh_gl(
 			glGenBuffers(1, &VBO[i]);
 			vbosize = verts.size();
 			glBindBuffer(GL_ARRAY_BUFFER, VBO[i]);
-			glBufferData(GL_ARRAY_BUFFER, vbosize * sizeof(Vector3f), NULL, GL_DYNAMIC_COPY);
+			glBufferData(GL_ARRAY_BUFFER, vbosize * sizeof(vec3), NULL, GL_DYNAMIC_COPY);
 			cudaGLRegisterBufferObject(VBO[i]);
 		}
 	}
@@ -155,13 +154,13 @@ void draw_mesh_gl(
 	}
 	void *ptr=nullptr;
 	cudaGLMapBufferObject(&ptr, VBO[0]);
-	if (ptr) cudaMemcpy(ptr, verts.data(), vbosize * sizeof(Vector3f), cudaMemcpyDeviceToDevice);
+	if (ptr) cudaMemcpy(ptr, verts.data(), vbosize * sizeof(vec3), cudaMemcpyDeviceToDevice);
 	cudaGLMapBufferObject(&ptr, VBO[1]);
-	if (ptr) cudaMemcpy(ptr, normals.data(), vbosize * sizeof(Vector3f), cudaMemcpyDeviceToDevice);
+	if (ptr) cudaMemcpy(ptr, normals.data(), vbosize * sizeof(vec3), cudaMemcpyDeviceToDevice);
 	cudaGLMapBufferObject(&ptr, VBO[2]);
-	if (ptr) cudaMemcpy(ptr, colors.data(), vbosize * sizeof(Vector3f), cudaMemcpyDeviceToDevice);
+	if (ptr) cudaMemcpy(ptr, colors.data(), vbosize * sizeof(vec3), cudaMemcpyDeviceToDevice);
 
-	//std::vector<Vector3f> cpucols; cpucols.resize(verts.size());
+	//std::vector<vec3> cpucols; cpucols.resize(verts.size());
 	//colors.copy_to_host(cpucols);
 
 	cudaGLUnmapBufferObject(VBO[2]);
@@ -214,15 +213,14 @@ void main() {
 			program = 0;
 		}
 	}
-	Matrix4f view2world=Matrix4f::Identity();
-	view2world.block<3,4>(0,0) = camera_matrix;
-	Matrix4f world2view = view2world.inverse();
+	mat4 view2world = camera_matrix;
+	mat4 world2view = inverse(view2world);
 	glBindVertexArray(VAO);
 	glUseProgram(program);
 	glUniformMatrix4fv(glGetUniformLocation(program, "camera"), 1, GL_FALSE, (GLfloat*)&world2view);
-	glUniform2f(glGetUniformLocation(program, "f"), focal_length.x(), focal_length.y());
-	glUniform2f(glGetUniformLocation(program, "cen"), screen_center.x()*2.f-1.f, screen_center.y()*-2.f+1.f);
-	glUniform2i(glGetUniformLocation(program, "res"), resolution.x(), resolution.y());
+	glUniform2f(glGetUniformLocation(program, "f"), focal_length.x, focal_length.y);
+	glUniform2f(glGetUniformLocation(program, "cen"), screen_center.x*2.f-1.f, screen_center.y*-2.f+1.f);
+	glUniform2i(glGetUniformLocation(program, "res"), resolution.x, resolution.y);
 	glUniform1i(glGetUniformLocation(program, "mode"), mesh_render_mode);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, els);
 	GLuint posat = (GLuint)glGetAttribLocation(program, "pos");
@@ -262,19 +260,19 @@ with z=1
 
 edges 8-11 go in +z direction from vertex 0-3
 */
-__global__ void gen_vertices(BoundingBox render_aabb, Matrix3f render_aabb_to_local, Vector3i res_3d, const float* __restrict__ density, int*__restrict__ vertidx_grid, Vector3f* verts_out, float thresh, uint32_t* __restrict__ counters) {
+__global__ void gen_vertices(BoundingBox render_aabb, mat3 render_aabb_to_local, ivec3 res_3d, const float* __restrict__ density, int*__restrict__ vertidx_grid, vec3* verts_out, float thresh, uint32_t* __restrict__ counters) {
 	uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
 	uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
 	uint32_t z = blockIdx.z * blockDim.z + threadIdx.z;
-	if (x>=res_3d.x() || y>=res_3d.y() || z>=res_3d.z()) return;
-	Vector3f scale=(render_aabb.max-render_aabb.min).cwiseQuotient((res_3d-Vector3i::Ones()).cast<float>());
-	Vector3f offset=render_aabb.min;
-	uint32_t res2=res_3d.x()*res_3d.y();
-	uint32_t res3=res_3d.x()*res_3d.y()*res_3d.z();
-	uint32_t idx=x+y*res_3d.x()+z*res2;
+	if (x>=res_3d.x || y>=res_3d.y || z>=res_3d.z) return;
+	vec3 scale = (render_aabb.max - render_aabb.min) / vec3(res_3d - ivec3(1));
+	vec3 offset=render_aabb.min;
+	uint32_t res2=res_3d.x*res_3d.y;
+	uint32_t res3=res_3d.x*res_3d.y*res_3d.z;
+	uint32_t idx=x+y*res_3d.x+z*res2;
 	float f0 = density[idx];
 	bool inside=(f0>thresh);
-	if (x<res_3d.x()-1) {
+	if (x<res_3d.x-1) {
 		float f1 = density[idx+1];
 		if (inside != (f1>thresh)) {
 			uint32_t vidx = atomicAdd(counters,1);
@@ -282,23 +280,23 @@ __global__ void gen_vertices(BoundingBox render_aabb, Matrix3f render_aabb_to_lo
 				vertidx_grid[idx]=vidx+1;
 				float prevf=f0,nextf=f1;
 				float dt=((thresh-prevf)/(nextf-prevf));
-				verts_out[vidx]=render_aabb_to_local.transpose() * (Vector3f{float(x)+dt, float(y), float(z)}.cwiseProduct(scale) + offset);
+				verts_out[vidx] = transpose(render_aabb_to_local) * (vec3{float(x)+dt, float(y), float(z)} * scale + offset);
 			}
 		}
 	}
-	if (y<res_3d.y()-1) {
-		float f1 = density[idx+res_3d.x()];
+	if (y<res_3d.y-1) {
+		float f1 = density[idx+res_3d.x];
 		if (inside != (f1>thresh)) {
 			uint32_t vidx = atomicAdd(counters,1);
 			if (verts_out) {
 				vertidx_grid[idx+res3]=vidx+1;
 				float prevf=f0,nextf=f1;
 				float dt=((thresh-prevf)/(nextf-prevf));
-				verts_out[vidx]=render_aabb_to_local.transpose() * (Vector3f{float(x), float(y)+dt, float(z)}.cwiseProduct(scale) + offset);
+				verts_out[vidx] = transpose(render_aabb_to_local) * (vec3{float(x), float(y)+dt, float(z)} * scale + offset);
 			}
 		}
 	}
-	if (z<res_3d.z()-1) {
+	if (z<res_3d.z-1) {
 		float f1 = density[idx+res2];
 		if (inside != (f1>thresh)) {
 			uint32_t vidx = atomicAdd(counters,1);
@@ -306,59 +304,59 @@ __global__ void gen_vertices(BoundingBox render_aabb, Matrix3f render_aabb_to_lo
 				vertidx_grid[idx+res3*2]=vidx+1;
 				float prevf=f0,nextf=f1;
 				float dt=((thresh-prevf)/(nextf-prevf));
-				verts_out[vidx]=render_aabb_to_local.transpose() * (Vector3f{float(x), float(y), float(z)+dt}.cwiseProduct(scale) + offset);
+				verts_out[vidx] = transpose(render_aabb_to_local) * (vec3{float(x), float(y), float(z)+dt} * scale + offset);
 			}
 		}
 	}
 }
 
-__global__ void accumulate_1ring(uint32_t num_tris, const uint32_t* indices, const Vector3f* verts_in, Vector4f* verts_out, Vector3f *normals_out) {
+__global__ void accumulate_1ring(uint32_t num_tris, const uint32_t* indices, const vec3* verts_in, vec4* verts_out, vec3 *normals_out) {
 	uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
 	if (i>=num_tris) return;
 	uint32_t ia=indices[i*3+0];
 	uint32_t ib=indices[i*3+1];
 	uint32_t ic=indices[i*3+2];
-	Vector3f pa=verts_in[ia];
-	Vector3f pb=verts_in[ib];
-	Vector3f pc=verts_in[ic];
+	vec3 pa=verts_in[ia];
+	vec3 pb=verts_in[ib];
+	vec3 pc=verts_in[ic];
 
-	atomicAdd(&verts_out[ia][0], pb.x()+pc.x());
-	atomicAdd(&verts_out[ia][1], pb.y()+pc.y());
-	atomicAdd(&verts_out[ia][2], pb.z()+pc.z());
+	atomicAdd(&verts_out[ia][0], pb.x+pc.x);
+	atomicAdd(&verts_out[ia][1], pb.y+pc.y);
+	atomicAdd(&verts_out[ia][2], pb.z+pc.z);
 	atomicAdd(&verts_out[ia][3], 2.f);
-	atomicAdd(&verts_out[ib][0], pa.x()+pc.x());
-	atomicAdd(&verts_out[ib][1], pa.y()+pc.y());
-	atomicAdd(&verts_out[ib][2], pa.z()+pc.z());
+	atomicAdd(&verts_out[ib][0], pa.x+pc.x);
+	atomicAdd(&verts_out[ib][1], pa.y+pc.y);
+	atomicAdd(&verts_out[ib][2], pa.z+pc.z);
 	atomicAdd(&verts_out[ib][3], 2.f);
-	atomicAdd(&verts_out[ic][0], pb.x()+pa.x());
-	atomicAdd(&verts_out[ic][1], pb.y()+pa.y());
-	atomicAdd(&verts_out[ic][2], pb.z()+pa.z());
+	atomicAdd(&verts_out[ic][0], pb.x+pa.x);
+	atomicAdd(&verts_out[ic][1], pb.y+pa.y);
+	atomicAdd(&verts_out[ic][2], pb.z+pa.z);
 	atomicAdd(&verts_out[ic][3], 2.f);
 
 	if (normals_out) {
-		Vector3f n= (pb-pa).cross(pa-pc); // don't normalise so it's weighted by area
-		atomicAdd(&normals_out[ia][0], n.x());
-		atomicAdd(&normals_out[ia][1], n.y());
-		atomicAdd(&normals_out[ia][2], n.z());
-		atomicAdd(&normals_out[ib][0], n.x());
-		atomicAdd(&normals_out[ib][1], n.y());
-		atomicAdd(&normals_out[ib][2], n.z());
-		atomicAdd(&normals_out[ic][0], n.x());
-		atomicAdd(&normals_out[ic][1], n.y());
-		atomicAdd(&normals_out[ic][2], n.z());
+		vec3 n= cross(pb - pa, pa - pc); // don't normalise so it's weighted by area
+		atomicAdd(&normals_out[ia][0], n.x);
+		atomicAdd(&normals_out[ia][1], n.y);
+		atomicAdd(&normals_out[ia][2], n.z);
+		atomicAdd(&normals_out[ib][0], n.x);
+		atomicAdd(&normals_out[ib][1], n.y);
+		atomicAdd(&normals_out[ib][2], n.z);
+		atomicAdd(&normals_out[ic][0], n.x);
+		atomicAdd(&normals_out[ic][1], n.y);
+		atomicAdd(&normals_out[ic][2], n.z);
 	}
 }
 
-__global__ void compute_centroids(uint32_t num_verts, Vector3f* centroids_out, const Vector4f* verts_in) {
+__global__ void compute_centroids(uint32_t num_verts, vec3* centroids_out, const vec4* verts_in) {
 	uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
 	if (i>=num_verts) return;
-	Vector4f p = verts_in[i];
-	if (p.w()<=0.f) return;
-	Vector3f c=verts_in[i].head<3>() * (1.f/p.w());
+	vec4 p = verts_in[i];
+	if (p.w<=0.f) return;
+	vec3 c = verts_in[i].xyz * (1.f / p.w);
 	centroids_out[i]=c;
 }
 
-__global__ void gen_faces(Vector3i res_3d, const float* __restrict__ density, const int*__restrict__ vertidx_grid, uint32_t* indices_out, float thresh, uint32_t *__restrict__ counters) {
+__global__ void gen_faces(ivec3 res_3d, const float* __restrict__ density, const int*__restrict__ vertidx_grid, uint32_t* indices_out, float thresh, uint32_t *__restrict__ counters) {
 	// marching cubes tables from https://github.com/pmneila/PyMCubes/blob/master/mcubes/src/marchingcubes.cpp which in turn seems to be from https://web.archive.org/web/20181127124338/http://paulbourke.net/geometry/polygonise/
 	// License is BSD 3-clause, which can be found here: https://github.com/pmneila/PyMCubes/blob/master/LICENSE
 	/*
@@ -645,11 +643,11 @@ __global__ void gen_faces(Vector3i res_3d, const float* __restrict__ density, co
 	uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
 	uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
 	uint32_t z = blockIdx.z * blockDim.z + threadIdx.z;
-	if (x>=res_3d.x()-1 || y>=res_3d.y()-1 || z>=res_3d.z()-1) return;
-	uint32_t res1=res_3d.x();
-	uint32_t res2=res_3d.x()*res_3d.y();
-	uint32_t res3=res_3d.x()*res_3d.y()*res_3d.z();
-	uint32_t idx=x+y*res_3d.x()+z*res2;
+	if (x>=res_3d.x-1 || y>=res_3d.y-1 || z>=res_3d.z-1) return;
+	uint32_t res1=res_3d.x;
+	uint32_t res2=res_3d.x*res_3d.y;
+	uint32_t res3=res_3d.x*res_3d.y*res_3d.z;
+	uint32_t idx=x+y*res_3d.x+z*res2;
 
 	uint32_t idx_x=idx;
 	uint32_t idx_y=idx+res3;
@@ -701,7 +699,7 @@ __global__ void gen_faces(Vector3i res_3d, const float* __restrict__ density, co
 	}
 }
 
-void compute_mesh_1ring(const tcnn::GPUMemory<Vector3f> &verts, const tcnn::GPUMemory<uint32_t> &indices, tcnn::GPUMemory<Vector4f> &output_pos, tcnn::GPUMemory<Vector3f> &output_normals) { // computes the average of the 1ring of all verts, as homogenous coordinates
+void compute_mesh_1ring(const tcnn::GPUMemory<vec3> &verts, const tcnn::GPUMemory<uint32_t> &indices, tcnn::GPUMemory<vec4> &output_pos, tcnn::GPUMemory<vec3> &output_normals) { // computes the average of the 1ring of all verts, as homogenous coordinates
 	output_pos.resize(verts.size());
 	output_pos.memset(0);
 	output_normals.resize(verts.size());
@@ -712,13 +710,13 @@ void compute_mesh_1ring(const tcnn::GPUMemory<Vector3f> &verts, const tcnn::GPUM
 __global__ void compute_mesh_opt_gradients_kernel(
 	uint32_t n_verts,
 	float thresh,
-	const Vector3f* verts,
-	const Vector3f* normals,
-	const Vector4f* verts_smoothed,
+	const vec3* verts,
+	const vec3* normals,
+	const vec4* verts_smoothed,
 	const network_precision_t* densities,
 	uint32_t input_gradient_width,
 	const float* input_gradients,
-	Vector3f* verts_gradient_out,
+	vec3* verts_gradient_out,
 	float k_smooth_amount,
 	float k_density_amount,
 	float k_inflate_amount
@@ -726,32 +724,32 @@ __global__ void compute_mesh_opt_gradients_kernel(
 	uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
 	if (i >= n_verts) return;
 
-	Vector3f src = verts[i];
-	Vector4f p = verts_smoothed[i];
+	vec3 src = verts[i];
+	vec4 p = verts_smoothed[i];
 
-	if (p.w() <= 0.f) {
-		p.w() = 1.f;
+	if (p.w <= 0.f) {
+		p.w = 1.f;
 	}
 
-	Vector3f target=p.head<3>() * (1.f/p.w());
-	Vector3f smoothing_grad = src - target; // negative...
+	vec3 target = p.xyz * (1.0f / p.w);
+	vec3 smoothing_grad = src - target; // negative...
 
-	Vector3f input_gradient = *(const Vector3f *)(input_gradients + i * input_gradient_width);
+	vec3 input_gradient = *(const vec3 *)(input_gradients + i * input_gradient_width);
 
-	Vector3f n = input_gradient.normalized();
+	vec3 n = normalize(input_gradient);
 	float density = densities[i];
-	verts_gradient_out[i] = n * sign(density - thresh) * k_density_amount + smoothing_grad * k_smooth_amount - normals[i].normalized() * k_inflate_amount;
+	verts_gradient_out[i] = n * sign(density - thresh) * k_density_amount + smoothing_grad * k_smooth_amount - normalize(normals[i]) * k_inflate_amount;
 }
 
 void compute_mesh_opt_gradients(
 	float thresh,
-	const tcnn::GPUMemory<Vector3f>& verts,
-	const tcnn::GPUMemory<Vector3f>& normals,
-	const tcnn::GPUMemory<Vector4f>& verts_smoothed,
+	const tcnn::GPUMemory<vec3>& verts,
+	const tcnn::GPUMemory<vec3>& normals,
+	const tcnn::GPUMemory<vec4>& verts_smoothed,
 	const network_precision_t* densities,
 	uint32_t input_gradients_width,
 	const float* input_gradients,
-	GPUMemory<Vector3f>& verts_gradient_out,
+	GPUMemory<vec3>& verts_gradient_out,
 	float k_smooth_amount,
 	float k_density_amount,
 	float k_inflate_amount
@@ -775,20 +773,20 @@ void compute_mesh_opt_gradients(
 	);
 }
 
-void marching_cubes_gpu(cudaStream_t stream, BoundingBox render_aabb, Matrix3f render_aabb_to_local, Vector3i res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<Vector3f>& verts_out, tcnn::GPUMemory<uint32_t>& indices_out) {
+void marching_cubes_gpu(cudaStream_t stream, BoundingBox render_aabb, mat3 render_aabb_to_local, ivec3 res_3d, float thresh, const tcnn::GPUMemory<float>& density, tcnn::GPUMemory<vec3>& verts_out, tcnn::GPUMemory<uint32_t>& indices_out) {
 	GPUMemory<uint32_t> counters;
 
 	counters.enlarge(4);
 	counters.memset(0);
 
-	size_t n_bytes = res_3d.x() * (size_t)res_3d.y() * res_3d.z() * 3 * sizeof(int);
+	size_t n_bytes = res_3d.x * (size_t)res_3d.y * res_3d.z * 3 * sizeof(int);
 	auto workspace = allocate_workspace(stream, n_bytes);
 	CUDA_CHECK_THROW(cudaMemsetAsync(workspace.data(), -1, n_bytes, stream));
 
 	int* vertex_grid = (int*)workspace.data();
 
 	const dim3 threads = { 4, 4, 4 };
-	const dim3 blocks = { div_round_up((uint32_t)res_3d.x(), threads.x), div_round_up((uint32_t)res_3d.y(), threads.y), div_round_up((uint32_t)res_3d.z(), threads.z) };
+	const dim3 blocks = { div_round_up((uint32_t)res_3d.x, threads.x), div_round_up((uint32_t)res_3d.y, threads.y), div_round_up((uint32_t)res_3d.z, threads.z) };
 	// count only
 	gen_vertices<<<blocks, threads, 0>>>(render_aabb, render_aabb_to_local, res_3d, density.data(), nullptr, nullptr, thresh, counters.data());
 	gen_faces<<<blocks, threads, 0>>>(res_3d, density.data(), nullptr, nullptr, thresh, counters.data());
@@ -806,18 +804,18 @@ void marching_cubes_gpu(cudaStream_t stream, BoundingBox render_aabb, Matrix3f r
 }
 
 void save_mesh(
-	GPUMemory<Vector3f>& verts,
-	GPUMemory<Vector3f>& normals,
-	GPUMemory<Vector3f>& colors,
+	GPUMemory<vec3>& verts,
+	GPUMemory<vec3>& normals,
+	GPUMemory<vec3>& colors,
 	GPUMemory<uint32_t>& indices,
 	const fs::path& path,
 	bool unwrap_it,
 	float nerf_scale,
-	Vector3f nerf_offset
+	vec3 nerf_offset
 ) {
-	std::vector<Vector3f> cpuverts; cpuverts.resize(verts.size());
-	std::vector<Vector3f> cpunormals; cpunormals.resize(normals.size());
-	std::vector<Vector3f> cpucolors; cpucolors.resize(colors.size());
+	std::vector<vec3> cpuverts; cpuverts.resize(verts.size());
+	std::vector<vec3> cpunormals; cpunormals.resize(normals.size());
+	std::vector<vec3> cpucolors; cpucolors.resize(colors.size());
 	std::vector<uint32_t> cpuindices; cpuindices.resize(indices.size());
 	verts.copy_to_host(cpuverts);
 	normals.copy_to_host(cpunormals);
@@ -887,14 +885,14 @@ void save_mesh(
 		);
 
 		for (size_t i=0;i<cpuverts.size();++i) {
-			Vector3f p=(cpuverts[i]-nerf_offset)/nerf_scale;
-			Vector3f c=cpucolors[i];
-			Vector3f n=cpunormals[i].normalized();
-			unsigned char c8[3]={(unsigned char)tcnn::clamp(c.x()*255.f,0.f,255.f),(unsigned char)tcnn::clamp(c.y()*255.f,0.f,255.f),(unsigned char)tcnn::clamp(c.z()*255.f,0.f,255.f)};
-			fprintf(f, "%0.5f %0.5f %0.5f %0.3f %0.3f %0.3f %d %d %d\n", p.x(), p.y(), p.z(), n.x(), n.y(), n.z(), c8[0], c8[1], c8[2]);
+			vec3 p = (cpuverts[i]-nerf_offset)/nerf_scale;
+			vec3 c = cpucolors[i];
+			vec3 n = normalize(cpunormals[i]);
+			unsigned char c8[3] = {(unsigned char)tcnn::clamp(c.x*255.f,0.f,255.f),(unsigned char)tcnn::clamp(c.y*255.f,0.f,255.f),(unsigned char)tcnn::clamp(c.z*255.f,0.f,255.f)};
+			fprintf(f, "%0.5f %0.5f %0.5f %0.3f %0.3f %0.3f %d %d %d\n", p.x, p.y, p.z, n.x, n.y, n.z, c8[0], c8[1], c8[2]);
 		}
 
-		for (size_t i=0;i<cpuindices.size();i+=3) {
+		for (size_t i = 0; i < cpuindices.size(); i += 3) {
 			fprintf(f, "3 %d %d %d\n", cpuindices[i+2], cpuindices[i+1], cpuindices[i+0]);
 		}
 	} else {
@@ -904,14 +902,14 @@ void save_mesh(
 		}
 
 		for (size_t i = 0; i < cpuverts.size(); ++i) {
-			Vector3f p = (cpuverts[i]-nerf_offset)/nerf_scale;
-			Vector3f c = cpucolors[i];
-			fprintf(f, "v %0.5f %0.5f %0.5f %0.3f %0.3f %0.3f\n", p.x(), p.y(), p.z(), tcnn::clamp(c.x(), 0.f, 1.f), tcnn::clamp(c.y(), 0.f, 1.f), tcnn::clamp(c.z(), 0.f, 1.f));
+			vec3 p = (cpuverts[i]-nerf_offset)/nerf_scale;
+			vec3 c = cpucolors[i];
+			fprintf(f, "v %0.5f %0.5f %0.5f %0.3f %0.3f %0.3f\n", p.x, p.y, p.z, tcnn::clamp(c.x, 0.f, 1.f), tcnn::clamp(c.y, 0.f, 1.f), tcnn::clamp(c.z, 0.f, 1.f));
 		}
 
 		for (auto &v: cpunormals) {
-			auto n = v.normalized();
-			fprintf(f, "vn %0.5f %0.5f %0.5f\n", n.x(), n.y(), n.z());
+			auto n = normalize(v);
+			fprintf(f, "vn %0.5f %0.5f %0.5f\n", n.x, n.y, n.z);
 		}
 
 		if (unwrap_it) {
@@ -950,38 +948,38 @@ void save_mesh(
 	fclose(f);
 }
 
-void save_density_grid_to_png(const GPUMemory<float>& density, const fs::path& path, Vector3i res3d, float thresh, bool swap_y_z, float density_range) {
+void save_density_grid_to_png(const GPUMemory<float>& density, const fs::path& path, ivec3 res3d, float thresh, bool swap_y_z, float density_range) {
 	float density_scale = 128.f / density_range; // map from -density_range to density_range into 0-255
 	std::vector<float> density_cpu;
 	density_cpu.resize(density.size());
 	density.copy_to_host(density_cpu);
 	uint32_t num_voxels = 0;
 	uint32_t num_lattice_points_near_zero_crossing = 0;
-	uint32_t N = res3d.x()*res3d.y()*res3d.z();
-	for (int z = 1; z < res3d.z() - 1; ++z) {
-		for (int y = 1; y < res3d.y() - 1; ++y) {
-			for (int x = 1; x < res3d.x() - 1; ++x) {
+	uint32_t N = res3d.x*res3d.y*res3d.z;
+	for (int z = 1; z < res3d.z - 1; ++z) {
+		for (int y = 1; y < res3d.y - 1; ++y) {
+			for (int x = 1; x < res3d.x - 1; ++x) {
 				int count = 0;
-				count += density_cpu[(x+0)+(y+0)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+1)+(y+0)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+0)+(y+1)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+1)+(y+1)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+0)+(y+0)*res3d.x()+(z+1)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+1)+(y+0)*res3d.x()+(z+1)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+0)+(y+1)*res3d.x()+(z+1)*res3d.x()*res3d.y()] < thresh;
-				count += density_cpu[(x+1)+(y+1)*res3d.x()+(z+1)*res3d.x()*res3d.y()] < thresh;
+				count += density_cpu[(x+0)+(y+0)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+1)+(y+0)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+0)+(y+1)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+1)+(y+1)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+0)+(y+0)*res3d.x+(z+1)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+1)+(y+0)*res3d.x+(z+1)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+0)+(y+1)*res3d.x+(z+1)*res3d.x*res3d.y] < thresh;
+				count += density_cpu[(x+1)+(y+1)*res3d.x+(z+1)*res3d.x*res3d.y] < thresh;
 				if (count>0 && count<8) {
 					num_voxels++;
 				}
 
-				bool mysign = density_cpu[(x+0)+(y+0)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh;
+				bool mysign = density_cpu[(x+0)+(y+0)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh;
 				bool near_zero_crossing=false;
-				near_zero_crossing |= (density_cpu[(x+1)+(y+0)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh) != mysign;
-				near_zero_crossing |= (density_cpu[(x-1)+(y+0)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh) != mysign;
-				near_zero_crossing |= (density_cpu[(x+0)+(y+1)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh) != mysign;
-				near_zero_crossing |= (density_cpu[(x+0)+(y-1)*res3d.x()+(z+0)*res3d.x()*res3d.y()] < thresh) != mysign;
-				near_zero_crossing |= (density_cpu[(x+0)+(y+0)*res3d.x()+(z+1)*res3d.x()*res3d.y()] < thresh) != mysign;
-				near_zero_crossing |= (density_cpu[(x+0)+(y+0)*res3d.x()+(z-1)*res3d.x()*res3d.y()] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x+1)+(y+0)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x-1)+(y+0)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x+0)+(y+1)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x+0)+(y-1)*res3d.x+(z+0)*res3d.x*res3d.y] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x+0)+(y+0)*res3d.x+(z+1)*res3d.x*res3d.y] < thresh) != mysign;
+				near_zero_crossing |= (density_cpu[(x+0)+(y+0)*res3d.x+(z-1)*res3d.x*res3d.y] < thresh) != mysign;
 				if (near_zero_crossing) {
 					num_lattice_points_near_zero_crossing++;
 				}
@@ -991,25 +989,25 @@ void save_density_grid_to_png(const GPUMemory<float>& density, const fs::path& p
 
 
 	if (swap_y_z) {
-		res3d = {res3d.x(), res3d.z(), res3d.y()};
+		res3d = {res3d.x, res3d.z, res3d.y};
 	}
 
-	uint32_t ndown = uint32_t(sqrtf(res3d.z()));
-	uint32_t nacross = (res3d.z()+ndown-1)/ndown;
-	uint32_t w = res3d.x() * nacross;
-	uint32_t h = res3d.y() * ndown;
+	uint32_t ndown = uint32_t(sqrtf(res3d.z));
+	uint32_t nacross = (res3d.z+ndown-1)/ndown;
+	uint32_t w = res3d.x * nacross;
+	uint32_t h = res3d.y * ndown;
 	uint8_t* pngpixels = (uint8_t *)malloc(size_t(w)*size_t(h));
 	uint8_t* dst = pngpixels;
 	for (int v = 0; v < h; ++v) {
 		for (int u = 0; u < w; ++u) {
-			int x = u % res3d.x();
-			int y = v % res3d.y();
-			int z = (u / res3d.x()) + (v / res3d.y()) * nacross;
-			if (z < res3d.z()) {
+			int x = u % res3d.x;
+			int y = v % res3d.y;
+			int z = (u / res3d.x) + (v / res3d.y) * nacross;
+			if (z < res3d.z) {
 				if (swap_y_z) {
-					*dst++ = (uint8_t)tcnn::clamp((density_cpu[x + z*res3d.x() + y*res3d.x()*res3d.z()]-thresh)*density_scale + 128.5f, 0.f, 255.f);
+					*dst++ = (uint8_t)tcnn::clamp((density_cpu[x + z*res3d.x + y*res3d.x*res3d.z]-thresh)*density_scale + 128.5f, 0.f, 255.f);
 				} else {
-					*dst++ = (uint8_t)tcnn::clamp((density_cpu[x + (res3d.y()-1-y)*res3d.x() + z*res3d.x()*res3d.y()]-thresh)*density_scale + 128.5f, 0.f, 255.f);
+					*dst++ = (uint8_t)tcnn::clamp((density_cpu[x + (res3d.y-1-y)*res3d.x + z*res3d.x*res3d.y]-thresh)*density_scale + 128.5f, 0.f, 255.f);
 				}
 			} else {
 				*dst++ = 0;
@@ -1031,31 +1029,31 @@ void save_density_grid_to_png(const GPUMemory<float>& density, const fs::path& p
 // Distinct from `save_density_grid_to_png` not just in that is writes RGBA, but also
 // in that it writes a sequence of PNGs rather than a single large PNG.
 // TODO: make both methods configurable to do either single PNG or PNG sequence.
-void save_rgba_grid_to_png_sequence(const GPUMemory<Array4f>& rgba, const fs::path& path, Vector3i res3d, bool swap_y_z) {
-	std::vector<Array4f> rgba_cpu;
+void save_rgba_grid_to_png_sequence(const GPUMemory<vec4>& rgba, const fs::path& path, ivec3 res3d, bool swap_y_z) {
+	std::vector<vec4> rgba_cpu;
 	rgba_cpu.resize(rgba.size());
 	rgba.copy_to_host(rgba_cpu);
 
 	if (swap_y_z) {
-		res3d = {res3d.x(), res3d.z(), res3d.y()};
+		res3d = {res3d.x, res3d.z, res3d.y};
 	}
 
-	uint32_t w = res3d.x();
-	uint32_t h = res3d.y();
+	uint32_t w = res3d.x;
+	uint32_t h = res3d.y;
 
-	auto progress = tlog::progress(res3d.z());
+	auto progress = tlog::progress(res3d.z);
 
 	std::atomic<int> n_saved{0};
-	ThreadPool{}.parallel_for<int>(0, res3d.z(), [&](int z) {
+	ThreadPool{}.parallel_for<int>(0, res3d.z, [&](int z) {
 		uint8_t* pngpixels = (uint8_t*)malloc(size_t(w) * size_t(h) * 4);
 		uint8_t* dst = pngpixels;
 		for (int y = 0; y < h; ++y) {
 			for (int x = 0; x < w; ++x) {
-				size_t i = swap_y_z ? (x + z*res3d.x() + y*res3d.x()*res3d.z()) : (x + (res3d.y()-1-y)*res3d.x() + z*res3d.x()*res3d.y());
-				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].x() * 255.f, 0.f, 255.f);
-				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].y() * 255.f, 0.f, 255.f);
-				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].z() * 255.f, 0.f, 255.f);
-				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].w() * 255.f, 0.f, 255.f);
+				size_t i = swap_y_z ? (x + z*res3d.x + y*res3d.x*res3d.z) : (x + (res3d.y-1-y)*res3d.x + z*res3d.x*res3d.y);
+				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].x * 255.f, 0.f, 255.f);
+				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].y * 255.f, 0.f, 255.f);
+				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].z * 255.f, 0.f, 255.f);
+				*dst++ = (uint8_t)tcnn::clamp(rgba_cpu[i].w * 255.f, 0.f, 255.f);
 			}
 		}
 
@@ -1067,18 +1065,18 @@ void save_rgba_grid_to_png_sequence(const GPUMemory<Array4f>& rgba, const fs::pa
 	tlog::success() << "Wrote RGBA PNG sequence to " << path;
 }
 
-void save_rgba_grid_to_raw_file(const GPUMemory<Array4f>& rgba, const fs::path& path, Vector3i res3d, bool swap_y_z, int cascade) {
-	std::vector<Array4f> rgba_cpu;
+void save_rgba_grid_to_raw_file(const GPUMemory<vec4>& rgba, const fs::path& path, ivec3 res3d, bool swap_y_z, int cascade) {
+	std::vector<vec4> rgba_cpu;
 	rgba_cpu.resize(rgba.size());
 	rgba.copy_to_host(rgba_cpu);
 
 	if (swap_y_z) {
-		res3d = {res3d.x(), res3d.z(), res3d.y()};
+		res3d = {res3d.x, res3d.z, res3d.y};
 	}
 
-	uint32_t w = res3d.x();
-	uint32_t h = res3d.y();
-	uint32_t d = res3d.z();
+	uint32_t w = res3d.x;
+	uint32_t h = res3d.y;
+	uint32_t d = res3d.z;
 
 	auto actual_path = path / fmt::format("{}x{}x{}_{}.bin", w, h, d, cascade);
 	FILE* f = native_fopen(actual_path, "wb");
@@ -1089,11 +1087,11 @@ void save_rgba_grid_to_raw_file(const GPUMemory<Array4f>& rgba, const fs::path& 
 	for (int z = 0; z < d; ++z) {
 		for (int y = 0; y < h; ++y) {
 			for (int x = 0; x < w; ++x) {
-				size_t i = swap_y_z ? (x + z*res3d.x() + y*res3d.x()*res3d.z()) : (x + (res3d.y()-1-y)*res3d.x() + z*res3d.x()*res3d.y());
+				size_t i = swap_y_z ? (x + z*res3d.x + y*res3d.x*res3d.z) : (x + (res3d.y-1-y)*res3d.x + z*res3d.x*res3d.y);
 				float* rgba = (float*)&rgba_cpu[i];
 				// the intention is that if cascade > 0, we have set up the render aabb such that we are outputing exactly one cascade of the nerf
 				// we then punch a transparent hole in the middle of each cascade, so that they fit together when placed on top of each other.
-				if (cascade && x>=res3d.x()/4+border && y>=res3d.y()/4+border && z>=res3d.z()/4+border && x<res3d.x()-res3d.x()/4-border && y<res3d.y()-res3d.y()/4-border && z<res3d.z()-res3d.z()/4-border)
+				if (cascade && x>=res3d.x/4+border && y>=res3d.y/4+border && z>=res3d.z/4+border && x<res3d.x-res3d.x/4-border && y<res3d.y-res3d.y/4-border && z<res3d.z-res3d.z/4-border)
 					fwrite(zero, sizeof(float), 4, f);
 				else
 					fwrite(rgba, sizeof(float), 4, f);

--- a/src/optix/pathescape.cu
+++ b/src/optix/pathescape.cu
@@ -13,13 +13,12 @@
  *  @brief  Minimal optix program.
  */
 
-#include <neural-graphics-primitives/random_val.cuh>
 #include <neural-graphics-primitives/common_device.cuh>
+#include <neural-graphics-primitives/random_val.cuh>
 #include <optix.h>
 
 #include "pathescape.h"
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
@@ -29,37 +28,37 @@ extern "C" {
 }
 
 struct Onb {
-	inline __device__ Onb(const Vector3f& normal) {
+	inline __device__ Onb(const vec3& normal) {
 		m_normal = normal;
 
-		if (fabs(m_normal.x()) > fabs(m_normal.z())) {
-			m_binormal.x() = -m_normal.y();
-			m_binormal.y() =  m_normal.x();
-			m_binormal.z() =  0;
+		if (fabs(m_normal.x) > fabs(m_normal.z)) {
+			m_binormal.x = -m_normal.y;
+			m_binormal.y =  m_normal.x;
+			m_binormal.z =  0;
 		} else {
-			m_binormal.x() =  0;
-			m_binormal.y() = -m_normal.z();
-			m_binormal.z() =  m_normal.y();
+			m_binormal.x =  0;
+			m_binormal.y = -m_normal.z;
+			m_binormal.z =  m_normal.y;
 		}
 
-		m_binormal = m_binormal.normalized();
-		m_tangent = m_binormal.cross(m_normal);
+		m_binormal = normalize(m_binormal);
+		m_tangent = cross(m_binormal, m_normal);
 	}
 
-	inline __device__ void inverse_transform(Vector3f& p) const {
-		p = p.x()*m_tangent + p.y()*m_binormal + p.z()*m_normal;
+	inline __device__ void inverse_transform(vec3& p) const {
+		p = p.x*m_tangent + p.y*m_binormal + p.z*m_normal;
 	}
 
-	Vector3f m_tangent;
-	Vector3f m_binormal;
-	Vector3f m_normal;
+	vec3 m_tangent;
+	vec3 m_binormal;
+	vec3 m_normal;
 };
 
 extern "C" __global__ void __raygen__rg() {
 	const uint3 idx = optixGetLaunchIndex();
 	const uint3 dim = optixGetLaunchDimensions();
 
-	Vector3f query_point = params.ray_origins[idx.x];
+	vec3 query_point = params.ray_origins[idx.x];
 
 	static constexpr uint32_t N_PATHS = 32;
 	static constexpr uint32_t N_BOUNCES = 4;
@@ -68,8 +67,8 @@ extern "C" __global__ void __raygen__rg() {
 	rng.advance(idx.x * 4 * N_PATHS * N_BOUNCES);
 	uint32_t n_escaped = 0;
 	for (uint32_t i = 0; i < N_PATHS; ++i) {
-		Vector3f ray_origin = query_point;
-		Vector3f ray_direction = random_dir(rng);
+		vec3 ray_origin = query_point;
+		vec3 ray_direction = random_dir(rng);
 
 		for (uint32_t j = 0; j < N_BOUNCES; ++j) {
 			// Trace the stab ray against our scene hierarchy
@@ -99,9 +98,9 @@ extern "C" __global__ void __raygen__rg() {
 				break;
 			}
 
-			Vector3f N_0;
+			vec3 N_0;
 			float t = params.triangles[p0].ray_intersect(ray_origin, ray_direction, N_0);
-			const Vector3f N = faceforward(N_0, -ray_direction, N_0).normalized();
+			const vec3 N = normalize(faceforward(N_0, ray_direction, N_0));
 
 			// Prevent self-intersections by subtracting 1e-3f from the target distance.
 			ray_origin += ray_direction * fmaxf(0.0f, t - 1e-3f);

--- a/src/optix/pathescape.h
+++ b/src/optix/pathescape.h
@@ -24,7 +24,7 @@ NGP_NAMESPACE_BEGIN
 
 struct PathEscape {
 	struct Params {
-		const Eigen::Vector3f* ray_origins;
+		const vec3* ray_origins;
 		const Triangle* triangles;
 		float* distances;
 		OptixTraversableHandle handle;

--- a/src/optix/raystab.cu
+++ b/src/optix/raystab.cu
@@ -20,7 +20,6 @@
 
 #include "raystab.h"
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
@@ -33,17 +32,17 @@ extern "C" __global__ void __raygen__rg() {
 	const uint3 idx = optixGetLaunchIndex();
 	const uint3 dim = optixGetLaunchDimensions();
 
-	Vector3f ray_origin = params.ray_origins[idx.x];
+	vec3 ray_origin = params.ray_origins[idx.x];
 
 	default_rng_t rng;
 	rng.advance(idx.x * 2);
-	Vector2f offset = random_val_2d(rng);
+	vec2 offset = random_val_2d(rng);
 
 	static constexpr uint32_t N_STAB_RAYS = 32;
 	for (uint32_t i = 0; i < N_STAB_RAYS; ++i) {
 		// Use a Fibonacci lattice (with random offset) to regularly
 		// distribute the stab rays over the sphere.
-		Vector3f ray_direction = fibonacci_dir<N_STAB_RAYS>(i, offset);
+		vec3 ray_direction = fibonacci_dir<N_STAB_RAYS>(i, offset);
 
 		// Trace the stab ray against our scene hierarchy
 		unsigned int p0;

--- a/src/optix/raystab.h
+++ b/src/optix/raystab.h
@@ -23,7 +23,7 @@ NGP_NAMESPACE_BEGIN
 
 struct Raystab {
 	struct Params {
-		const Eigen::Vector3f* ray_origins;
+		const vec3* ray_origins;
 		float* distances;
 		OptixTraversableHandle handle;
 	};

--- a/src/optix/raytrace.cu
+++ b/src/optix/raytrace.cu
@@ -13,12 +13,10 @@
  *  @brief  Minimal optix program.
  */
 
+#include <neural-graphics-primitives/common_device.cuh>
 #include <optix.h>
 
 #include "raytrace.h"
-#include <neural-graphics-primitives/common_device.cuh>
-
-using namespace Eigen;
 
 NGP_NAMESPACE_BEGIN
 
@@ -30,8 +28,8 @@ extern "C" __global__ void __raygen__rg() {
 	const uint3 idx = optixGetLaunchIndex();
 	const uint3 dim = optixGetLaunchDimensions();
 
-	Vector3f ray_origin = params.ray_origins[idx.x];
-	Vector3f ray_direction = params.ray_directions[idx.x];
+	vec3 ray_origin = params.ray_origins[idx.x];
+	vec3 ray_direction = params.ray_directions[idx.x];
 
 	unsigned int p0, p1;
 	optixTrace(

--- a/src/optix/raytrace.h
+++ b/src/optix/raytrace.h
@@ -24,8 +24,8 @@ NGP_NAMESPACE_BEGIN
 
 struct Raytrace {
 	struct Params {
-		Eigen::Vector3f* ray_origins;
-		Eigen::Vector3f* ray_directions;
+		vec3* ray_origins;
+		vec3* ray_directions;
 		const Triangle* triangles;
 		OptixTraversableHandle handle;
 	};

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -19,10 +19,10 @@
 #include <json/json.hpp>
 
 #include <pybind11/pybind11.h>
-#include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <pybind11_glm/pybind11_glm.hpp>
 #include <pybind11_json/pybind11_json.hpp>
 
 #include <filesystem/path.h>
@@ -38,7 +38,6 @@
 #endif
 
 using namespace tcnn;
-using namespace Eigen;
 using namespace nlohmann;
 namespace py = pybind11;
 
@@ -76,14 +75,14 @@ void Testbed::override_sdf_training_data(py::array_t<float> points, py::array_t<
 		return;
 	}
 
-	std::vector<Vector3f> points_cpu(points_buf.shape[0]);
+	std::vector<vec3> points_cpu(points_buf.shape[0]);
 	std::vector<float> distances_cpu(distances_buf.shape[0]);
 
 	for (size_t i = 0; i < points_cpu.size(); ++i) {
-		Vector3f pos = *((Vector3f*)points_buf.ptr + i);
+		vec3 pos = *((vec3*)points_buf.ptr + i);
 		float dist = *((float*)distances_buf.ptr + i);
 
-		pos = (pos - m_raw_aabb.min) / m_sdf.mesh_scale + 0.5f * (Vector3f::Ones() - (m_raw_aabb.max - m_raw_aabb.min) / m_sdf.mesh_scale);
+		pos = (pos - m_raw_aabb.min) / m_sdf.mesh_scale + 0.5f * (vec3(1.0f) - (m_raw_aabb.max - m_raw_aabb.min) / m_sdf.mesh_scale);
 		dist /= m_sdf.mesh_scale;
 
 		points_cpu[i] = pos;
@@ -99,8 +98,8 @@ void Testbed::override_sdf_training_data(py::array_t<float> points, py::array_t<
 	m_sdf.training.generate_sdf_data_online = false;
 }
 
-pybind11::dict Testbed::compute_marching_cubes_mesh(Eigen::Vector3i res3d, BoundingBox aabb, float thresh) {
-	Matrix3f render_aabb_to_local = Matrix3f::Identity();
+pybind11::dict Testbed::compute_marching_cubes_mesh(ivec3 res3d, BoundingBox aabb, float thresh) {
+	mat3 render_aabb_to_local = mat3(1.0f);
 	if (aabb.is_empty()) {
 		aabb = m_testbed_mode == ETestbedMode::Nerf ? m_render_aabb : m_aabb;
 		render_aabb_to_local = m_render_aabb_to_local;
@@ -117,9 +116,9 @@ pybind11::dict Testbed::compute_marching_cubes_mesh(Eigen::Vector3i res3d, Bound
 	CUDA_CHECK_THROW(cudaMemcpy(cpucolors.request().ptr, m_mesh.vert_colors.data() , m_mesh.vert_colors.size() * 3 * sizeof(float), cudaMemcpyDeviceToHost));
 	CUDA_CHECK_THROW(cudaMemcpy(cpuindices.request().ptr, m_mesh.indices.data() , m_mesh.indices.size() * sizeof(int), cudaMemcpyDeviceToHost));
 
-	Eigen::Vector3f* ns = (Eigen::Vector3f*)cpunormals.request().ptr;
+	vec3* ns = (vec3*)cpunormals.request().ptr;
 	for (size_t i = 0; i < m_mesh.vert_normals.size(); ++i) {
-		ns[i].normalize();
+		ns[i] = normalize(ns[i]);
 	}
 
 	return py::dict("V"_a=cpuverts, "N"_a=cpunormals, "C"_a=cpucolors, "F"_a=cpuindices);
@@ -164,7 +163,7 @@ py::array_t<float> Testbed::render_to_cpu(int width, int height, int spp, bool l
 		float end_alpha = ((float)i + 1.0f)/(float)spp * shutter_fraction;
 
 		auto sample_start_cam_matrix = start_cam_matrix;
-		auto sample_end_cam_matrix = log_space_lerp(start_cam_matrix, end_cam_matrix, shutter_fraction);
+		auto sample_end_cam_matrix = camera_lerp(start_cam_matrix, end_cam_matrix, shutter_fraction);
 		if (i == 0) {
 			prev_camera_matrix = sample_start_cam_matrix;
 		}
@@ -215,17 +214,16 @@ py::array_t<float> Testbed::view(bool linear, size_t view_idx) const {
 
 	auto res = render_buffer.out_resolution();
 
-	py::array_t<float> result({res.y(), res.x(), 4});
+	py::array_t<float> result({res.y, res.x, 4});
 	py::buffer_info buf = result.request();
 	float* data = (float*)buf.ptr;
 
-	CUDA_CHECK_THROW(cudaMemcpy2DFromArray(data, res.x() * sizeof(float) * 4, render_buffer.surface_provider().array(), 0, 0, res.x() * sizeof(float) * 4, res.y(), cudaMemcpyDeviceToHost));
+	CUDA_CHECK_THROW(cudaMemcpy2DFromArray(data, res.x * sizeof(float) * 4, render_buffer.surface_provider().array(), 0, 0, res.x * sizeof(float) * 4, res.y, cudaMemcpyDeviceToHost));
 
 	if (linear) {
-		ThreadPool{}.parallel_for<size_t>(0, res.y(), [&](size_t y) {
-			size_t base = y * res.x();
-			size_t base_reverse = (res.y() - y - 1) * res.x();
-			for (uint32_t x = 0; x < res.x(); ++x) {
+		ThreadPool{}.parallel_for<size_t>(0, res.y, [&](size_t y) {
+			size_t base = y * res.x;
+			for (uint32_t x = 0; x < res.x; ++x) {
 				size_t px = base + x;
 				data[px*4+0] = srgb_to_linear(data[px*4+0]);
 				data[px*4+1] = srgb_to_linear(data[px*4+1]);
@@ -239,19 +237,19 @@ py::array_t<float> Testbed::view(bool linear, size_t view_idx) const {
 
 #ifdef NGP_GUI
 py::array_t<float> Testbed::screenshot(bool linear, bool front_buffer) const {
-	std::vector<float> tmp(m_window_res.prod() * 4);
+	std::vector<float> tmp(compMul(m_window_res) * 4);
 	glReadBuffer(front_buffer ? GL_FRONT : GL_BACK);
-	glReadPixels(0, 0, m_window_res.x(), m_window_res.y(), GL_RGBA, GL_FLOAT, tmp.data());
+	glReadPixels(0, 0, m_window_res.x, m_window_res.y, GL_RGBA, GL_FLOAT, tmp.data());
 
-	py::array_t<float> result({m_window_res.y(), m_window_res.x(), 4});
+	py::array_t<float> result({m_window_res.y, m_window_res.x, 4});
 	py::buffer_info buf = result.request();
 	float* data = (float*)buf.ptr;
 
 	// Linear, alpha premultiplied, Y flipped
-	ThreadPool{}.parallel_for<size_t>(0, m_window_res.y(), [&](size_t y) {
-		size_t base = y * m_window_res.x();
-		size_t base_reverse = (m_window_res.y() - y - 1) * m_window_res.x();
-		for (uint32_t x = 0; x < m_window_res.x(); ++x) {
+	ThreadPool{}.parallel_for<size_t>(0, m_window_res.y, [&](size_t y) {
+		size_t base = y * m_window_res.x;
+		size_t base_reverse = (m_window_res.y - y - 1) * m_window_res.x;
+		for (uint32_t x = 0; x < m_window_res.x; ++x) {
 			size_t px = base + x;
 			size_t px_reverse = base_reverse + x;
 			data[px_reverse*4+0] = linear ? srgb_to_linear(tmp[px*4+0]) : tmp[px*4+0];
@@ -359,13 +357,13 @@ PYBIND11_MODULE(pyngp, m) {
 
 	py::class_<BoundingBox>(m, "BoundingBox")
 		.def(py::init<>())
-		.def(py::init<const Vector3f&, const Vector3f&>())
+		.def(py::init<const vec3&, const vec3&>())
 		.def("center", &BoundingBox::center)
 		.def("contains", &BoundingBox::contains)
 		.def("diag", &BoundingBox::diag)
 		.def("distance", &BoundingBox::distance)
 		.def("distance_sq", &BoundingBox::distance_sq)
-		.def("enlarge", py::overload_cast<const Vector3f&>(&BoundingBox::enlarge))
+		.def("enlarge", py::overload_cast<const vec3&>(&BoundingBox::enlarge))
 		.def("enlarge", py::overload_cast<const BoundingBox&>(&BoundingBox::enlarge))
 		.def("get_vertices", &BoundingBox::get_vertices)
 		.def("inflate", &BoundingBox::inflate)
@@ -455,7 +453,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_property("loop_animation", &Testbed::loop_animation, &Testbed::set_loop_animation)
 		.def("compute_and_save_png_slices", &Testbed::compute_and_save_png_slices,
 			py::arg("filename"),
-			py::arg("resolution") = Eigen::Vector3i::Constant(256),
+			py::arg("resolution") = ivec3(256),
 			py::arg("aabb") = BoundingBox{},
 			py::arg("thresh") = std::numeric_limits<float>::max(),
 			py::arg("density_range") = 4.f,
@@ -464,7 +462,7 @@ PYBIND11_MODULE(pyngp, m) {
 		)
 		.def("compute_and_save_marching_cubes_mesh", &Testbed::compute_and_save_marching_cubes_mesh,
 			py::arg("filename"),
-			py::arg("resolution") = Eigen::Vector3i::Constant(256),
+			py::arg("resolution") = ivec3(256),
 			py::arg("aabb") = BoundingBox{},
 			py::arg("thresh") = std::numeric_limits<float>::max(),
 			py::arg("generate_uvs_for_obj_file") = false,
@@ -474,7 +472,7 @@ PYBIND11_MODULE(pyngp, m) {
 			"If the aabb parameter specifies an inside-out (\"empty\") box (default), the current render_aabb bounding box is used."
 		)
 		.def("compute_marching_cubes_mesh", &Testbed::compute_marching_cubes_mesh,
-			py::arg("resolution") = Eigen::Vector3i::Constant(256),
+			py::arg("resolution") = ivec3(256),
 			py::arg("aabb") = BoundingBox{},
 			py::arg("thresh") = std::numeric_limits<float>::max(),
 			"Compute a marching cubes mesh from the current SDF or NeRF model. "

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -33,7 +33,6 @@
 
 #include <stb_image/stb_image.h>
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
@@ -47,14 +46,14 @@ void CudaSurface2D::free() {
 	m_surface = 0;
 	if (m_array) {
 		cudaFreeArray(m_array);
-		g_total_n_bytes_allocated -= m_size.prod() * sizeof(float) * m_n_channels;
+		g_total_n_bytes_allocated -= compMul(m_size) * sizeof(float) * m_n_channels;
 	}
 	m_array = nullptr;
-	m_size = Vector2i::Zero();
+	m_size = ivec2(0);
 	m_n_channels = 0;
 }
 
-void CudaSurface2D::resize(const Vector2i& size, int n_channels) {
+void CudaSurface2D::resize(const ivec2& size, int n_channels) {
 	if (size == m_size && n_channels == m_n_channels) {
 		return;
 	}
@@ -69,9 +68,9 @@ void CudaSurface2D::resize(const Vector2i& size, int n_channels) {
 		case 4: desc = cudaCreateChannelDesc<float4>(); break;
 		default: throw std::runtime_error{fmt::format("CudaSurface2D: unsupported number of channels {}", n_channels)};
 	}
-	CUDA_CHECK_THROW(cudaMallocArray(&m_array, &desc, size.x(), size.y(), cudaArraySurfaceLoadStore));
+	CUDA_CHECK_THROW(cudaMallocArray(&m_array, &desc, size.x, size.y, cudaArraySurfaceLoadStore));
 
-	g_total_n_bytes_allocated += m_size.prod() * sizeof(float) * n_channels;
+	g_total_n_bytes_allocated += compMul(m_size) * sizeof(float) * n_channels;
 
 	struct cudaResourceDesc resource_desc;
 	memset(&resource_desc, 0, sizeof(resource_desc));
@@ -125,7 +124,7 @@ void GLTexture::blit_from_cuda_mapping() {
 	const float* data_cpu = m_cuda_mapping->data_cpu();
 
 	glBindTexture(GL_TEXTURE_2D, m_texture_id);
-	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, m_size.x(), m_size.y(), 0, m_format, GL_FLOAT, data_cpu);
+	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, m_size.x, m_size.y, 0, m_format, GL_FLOAT, data_cpu);
 }
 
 void GLTexture::load(const fs::path& path) {
@@ -139,21 +138,21 @@ void GLTexture::load(const fs::path& path) {
 	load(out, { width, height }, 4);
 }
 
-void GLTexture::load(const float* data, Vector2i new_size, int n_channels) {
+void GLTexture::load(const float* data, ivec2 new_size, int n_channels) {
 	resize(new_size, n_channels, false);
 
 	glBindTexture(GL_TEXTURE_2D, m_texture_id);
-	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x(), new_size.y(), 0, m_format, GL_FLOAT, data);
+	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x, new_size.y, 0, m_format, GL_FLOAT, data);
 }
 
-void GLTexture::load(const uint8_t* data, Vector2i new_size, int n_channels) {
+void GLTexture::load(const uint8_t* data, ivec2 new_size, int n_channels) {
 	resize(new_size, n_channels, true);
 
 	glBindTexture(GL_TEXTURE_2D, m_texture_id);
-	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x(), new_size.y(), 0, m_format, GL_UNSIGNED_BYTE, data);
+	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x, new_size.y, 0, m_format, GL_UNSIGNED_BYTE, data);
 }
 
-void GLTexture::resize(const Vector2i& new_size, int n_channels, bool is_8bit) {
+void GLTexture::resize(const ivec2& new_size, int n_channels, bool is_8bit) {
 	if (m_size == new_size && m_n_channels == n_channels && m_is_8bit == is_8bit) {
 		return;
 	}
@@ -178,14 +177,14 @@ void GLTexture::resize(const Vector2i& new_size, int n_channels, bool is_8bit) {
 	m_size = new_size;
 	m_n_channels = n_channels;
 
-	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x(), new_size.y(), 0, m_format, is_8bit ? GL_UNSIGNED_BYTE : GL_FLOAT, nullptr);
+	glTexImage2D(GL_TEXTURE_2D, 0, m_internal_format, new_size.x, new_size.y, 0, m_format, is_8bit ? GL_UNSIGNED_BYTE : GL_FLOAT, nullptr);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 }
 
-GLTexture::CUDAMapping::CUDAMapping(GLuint texture_id, const Vector2i& size, int n_channels) : m_size{size}, m_n_channels{n_channels} {
+GLTexture::CUDAMapping::CUDAMapping(GLuint texture_id, const ivec2& size, int n_channels) : m_size{size}, m_n_channels{n_channels} {
 	static bool s_is_cuda_interop_supported = !is_wsl();
 	if (s_is_cuda_interop_supported) {
 		cudaError_t err = cudaGraphicsGLRegisterImage(&m_graphics_resource, texture_id, GL_TEXTURE_2D, cudaGraphicsRegisterFlagsSurfaceLoadStore);
@@ -199,7 +198,7 @@ GLTexture::CUDAMapping::CUDAMapping(GLuint texture_id, const Vector2i& size, int
 		// falling back to a regular cuda surface + CPU copy of data
 		m_cuda_surface = std::make_unique<CudaSurface2D>();
 		m_cuda_surface->resize(size, n_channels);
-		m_data_cpu.resize(m_size.prod() * n_channels);
+		m_data_cpu.resize(compMul(m_size) * n_channels);
 		return;
 	}
 
@@ -223,54 +222,53 @@ GLTexture::CUDAMapping::~CUDAMapping() {
 }
 
 const float* GLTexture::CUDAMapping::data_cpu() {
-	CUDA_CHECK_THROW(cudaMemcpy2DFromArray(m_data_cpu.data(), m_size.x() * sizeof(float) * m_n_channels, array(), 0, 0, m_size.x() * sizeof(float) * m_n_channels, m_size.y(), cudaMemcpyDeviceToHost));
+	CUDA_CHECK_THROW(cudaMemcpy2DFromArray(m_data_cpu.data(), m_size.x * sizeof(float) * m_n_channels, array(), 0, 0, m_size.x * sizeof(float) * m_n_channels, m_size.y, cudaMemcpyDeviceToHost));
 	return m_data_cpu.data();
 }
 #endif //NGP_GUI
 
-__global__ void accumulate_kernel(Vector2i resolution, Array4f* frame_buffer, Array4f* accumulate_buffer, float sample_count, EColorSpace color_space) {
+__global__ void accumulate_kernel(ivec2 resolution, vec4* frame_buffer, vec4* accumulate_buffer, float sample_count, EColorSpace color_space) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
-	uint32_t idx = x + resolution.x() * y;
+	uint32_t idx = x + resolution.x * y;
 
-	Array4f color = frame_buffer[idx];
-	Array4f tmp = accumulate_buffer[idx];
+	vec4 color = frame_buffer[idx];
+	vec4 tmp = accumulate_buffer[idx];
 
 	switch (color_space) {
 		case EColorSpace::VisPosNeg:
 			{
-				float val = color.x() - color.y();
-				float tmp_val = tmp.x() - tmp.y();
+				float val = color.x - color.y;
+				float tmp_val = tmp.x - tmp.y;
 
 				tmp_val = (tmp_val * sample_count + val) / (sample_count+1);
 
-				tmp.x() = fmaxf(tmp_val, 0.0f);
-				tmp.y() = fmaxf(-tmp_val, 0.0f);
+				tmp.x = fmaxf(tmp_val, 0.0f);
+				tmp.y = fmaxf(-tmp_val, 0.0f);
 				break;
 			}
 		case EColorSpace::SRGB:
-			color.head<3>() = linear_to_srgb(color.head<3>());
+			color.rgb = linear_to_srgb(color.rgb);
 			// fallthrough is intended!
 		case EColorSpace::Linear:
-			tmp.head<3>() = (tmp.head<3>() * sample_count + color.head<3>()) / (sample_count+1); break;
+			tmp.rgb = (tmp.rgb * sample_count + color.rgb) / (sample_count+1); break;
 	}
 
-	tmp.w() = (tmp.w() * sample_count + color.w()) / (sample_count+1);
-
+	tmp.a = (tmp.a * sample_count + color.a) / (sample_count+1);
 	accumulate_buffer[idx] = tmp;
 }
 
-__device__ Array3f tonemap(Array3f x, ETonemapCurve curve) {
+__device__ vec3 tonemap(vec3 x, ETonemapCurve curve) {
 	if (curve == ETonemapCurve::Identity) {
 		return x;
 	}
 
-	x = x.cwiseMax(0.f);
+	x = max(x, vec3(0.0f));
 
 	float k0, k1, k2, k3, k4, k5;
 	if (curve == ETonemapCurve::ACES) {
@@ -309,22 +307,22 @@ __device__ Array3f tonemap(Array3f x, ETonemapCurve curve) {
 		k3 = 4.0f * k3;
 		k4 = 2.0f * k4;
 	} else { //if (curve == ETonemapCurve::Reinhard)
-		const Vector3f luminance_coefficients = Vector3f(0.2126f, 0.7152f, 0.0722f);
-		float Y = luminance_coefficients.dot(x.matrix());
+		const vec3 luminance_coefficients = vec3(0.2126f, 0.7152f, 0.0722f);
+		float Y = dot(luminance_coefficients, x);
 
 		return x * (1.f / (Y + 1.0f));
 	}
 
-	Array3f color_sq = x * x;
-	Array3f nom = color_sq * k0 + k1 * x + k2;
-	Array3f denom = k3 * color_sq + k4 * x + k5;
+	vec3 color_sq = x * x;
+	vec3 nom = color_sq * k0 + k1 * x + k2;
+	vec3 denom = k3 * color_sq + k4 * x + k5;
 
-	Array3f tonemapped_color = nom / denom;
+	vec3 tonemapped_color = nom / denom;
 
 	return tonemapped_color;
 }
 
-__device__ Array3f tonemap(Array3f col, const Array3f& exposure, ETonemapCurve tonemap_curve, EColorSpace color_space, EColorSpace output_color_space) {
+__device__ vec3 tonemap(vec3 col, const vec3& exposure, ETonemapCurve tonemap_curve, EColorSpace color_space, EColorSpace output_color_space) {
 	// Conversion to output by
 	// 1. converting to linear. (VisPosNeg is treated as linear red/green)
 	if (color_space == EColorSpace::SRGB) {
@@ -332,7 +330,7 @@ __device__ Array3f tonemap(Array3f col, const Array3f& exposure, ETonemapCurve t
 	}
 
 	// 2. applying exposure in linear space
-	col *= Array3f::Constant(2.0f).pow(exposure);
+	col *= pow(vec3(2.0f), exposure);
 
 	// 3. tonemapping in linear space according to the specified curve
 	col = tonemap(col, tonemap_curve);
@@ -346,25 +344,25 @@ __device__ Array3f tonemap(Array3f col, const Array3f& exposure, ETonemapCurve t
 }
 
 __global__ void overlay_image_kernel(
-	Vector2i resolution,
+	ivec2 resolution,
 	float alpha,
-	Array3f exposure,
-	Array4f background_color,
+	vec3 exposure,
+	vec4 background_color,
 	const void* __restrict__ image,
 	EImageDataType image_data_type,
-	Vector2i image_resolution,
+	ivec2 image_resolution,
 	ETonemapCurve tonemap_curve,
 	EColorSpace color_space,
 	EColorSpace output_color_space,
 	int fov_axis,
 	float zoom,
-	Eigen::Vector2f screen_center,
+	vec2 screen_center,
 	cudaSurfaceObject_t surface
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
@@ -373,83 +371,81 @@ __global__ void overlay_image_kernel(
 	float fx = x+0.5f;
 	float fy = y+0.5f;
 
-	fx -= resolution.x() * 0.5f; fx /= zoom; fx += screen_center.x() * resolution.x();
-	fy -= resolution.y() * 0.5f; fy /= zoom; fy += screen_center.y() * resolution.y();
+	fx -= resolution.x * 0.5f; fx /= zoom; fx += screen_center.x * resolution.x;
+	fy -= resolution.y * 0.5f; fy /= zoom; fy += screen_center.y * resolution.y;
 
-	float u = (fx - resolution.x() * 0.5f) * scale  + image_resolution.x() * 0.5f;
-	float v = (fy - resolution.y() * 0.5f) * scale  + image_resolution.y() * 0.5f;
+	float u = (fx - resolution.x * 0.5f) * scale  + image_resolution.x * 0.5f;
+	float v = (fy - resolution.y * 0.5f) * scale  + image_resolution.y * 0.5f;
 
 	int srcx = floorf(u);
 	int srcy = floorf(v);
-	uint32_t idx = x + resolution.x() * y;
-	uint32_t srcidx = srcx + image_resolution.x() * srcy;
 
-	Array4f val;
-	if (srcx >= image_resolution.x() || srcy >= image_resolution.y() || srcx < 0 || srcy < 0) {
-		val = Array4f::Zero();
+	vec4 val;
+	if (srcx >= image_resolution.x || srcy >= image_resolution.y || srcx < 0 || srcy < 0) {
+		val = vec4(0.0f);
 	} else {
-		val = read_rgba(Vector2i{srcx, srcy}, image_resolution, image, image_data_type);
+		val = read_rgba(ivec2{srcx, srcy}, image_resolution, image, image_data_type);
 	}
 
-	Array4f color = {val[0], val[1], val[2], val[3]};
+	vec4 color = {val[0], val[1], val[2], val[3]};
 
 	// The background color is represented in SRGB, so convert
 	// to linear if that's not the space in which we're rendering.
 	if (color_space != EColorSpace::SRGB) {
-		background_color.head<3>() = srgb_to_linear(background_color.head<3>());
+		background_color.xyz = srgb_to_linear(background_color.xyz);
 	} else {
-		if (color.w() > 0) {
-			color.head<3>() = linear_to_srgb(color.head<3>() / color.w()) * color.w();
+		if (color.a > 0) {
+			color.rgb = linear_to_srgb(color.rgb() / color.a) * color.a;
 		} else {
-			color.head<3>() = Array3f::Zero();
+			color.rgb = vec3(0.0f);
 		}
 	}
 
-	float weight = (1 - color.w()) * background_color.w();
-	color.head<3>() += background_color.head<3>() * weight;
-	color.w() += weight;
+	float weight = (1 - color.a) * background_color.a;
+	color.rgb += background_color.rgb * weight;
+	color.a += weight;
 
-	color.head<3>() = tonemap(color.head<3>(), exposure, tonemap_curve, color_space, output_color_space);
+	color.rgb = tonemap(color.rgb, exposure, tonemap_curve, color_space, output_color_space);
 
-	Array4f prev_color;
+	vec4 prev_color;
 	surf2Dread((float4*)&prev_color, surface, x * sizeof(float4), y);
 	color = color * alpha + prev_color * (1.f-alpha);
 	surf2Dwrite(to_float4(color), surface, x * sizeof(float4), y);
 }
 
-__device__ Array3f colormap_turbo(float x) {
-	const Vector4f kRedVec4 =   Vector4f(0.13572138f, 4.61539260f, -42.66032258f, 132.13108234f);
-	const Vector4f kGreenVec4 = Vector4f(0.09140261f, 2.19418839f, 4.84296658f, -14.18503333f);
-	const Vector4f kBlueVec4 =  Vector4f(0.10667330f, 12.64194608f, -60.58204836f, 110.36276771f);
-	const Vector2f kRedVec2 =   Vector2f(-152.94239396f, 59.28637943f);
-	const Vector2f kGreenVec2 = Vector2f(4.27729857f, 2.82956604f);
-	const Vector2f kBlueVec2 =  Vector2f(-89.90310912f, 27.34824973f);
+__device__ vec3 colormap_turbo(float x) {
+	const vec4 kRedVec4 =   vec4(0.13572138f, 4.61539260f, -42.66032258f, 132.13108234f);
+	const vec4 kGreenVec4 = vec4(0.09140261f, 2.19418839f, 4.84296658f, -14.18503333f);
+	const vec4 kBlueVec4 =  vec4(0.10667330f, 12.64194608f, -60.58204836f, 110.36276771f);
+	const vec2 kRedVec2 =   vec2(-152.94239396f, 59.28637943f);
+	const vec2 kGreenVec2 = vec2(4.27729857f, 2.82956604f);
+	const vec2 kBlueVec2 =  vec2(-89.90310912f, 27.34824973f);
 
 	x = __saturatef(x);
-	Vector4f v4 = Vector4f{ 1.0f, x, x * x, x * x * x };
-	Vector2f v2 = Vector2f{ v4.w() * x, v4.w() * v4.z() };
-	return Array3f{
-		v4.dot(kRedVec4)   + v2.dot(kRedVec2),
-		v4.dot(kGreenVec4) + v2.dot(kGreenVec2),
-		v4.dot(kBlueVec4)  + v2.dot(kBlueVec2)
+	vec4 v4 = vec4{ 1.0f, x, x * x, x * x * x };
+	vec2 v2 = vec2{ v4.w * x, v4.w * v4.z };
+	return vec3{
+		dot(v4, kRedVec4)   + dot(v2, kRedVec2),
+		dot(v4, kGreenVec4) + dot(v2, kGreenVec2),
+		dot(v4, kBlueVec4)  + dot(v2, kBlueVec2)
 	};
 }
 
 __global__ void overlay_depth_kernel(
-	Vector2i resolution,
+	ivec2 resolution,
 	float alpha,
 	const float* __restrict__ depth,
 	float depth_scale,
-	Vector2i image_resolution,
+	ivec2 image_resolution,
 	int fov_axis,
 	float zoom,
-	Eigen::Vector2f screen_center,
+	vec2 screen_center,
 	cudaSurfaceObject_t surface
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
@@ -458,64 +454,62 @@ __global__ void overlay_depth_kernel(
 	float fx = x + 0.5f;
 	float fy = y + 0.5f;
 
-	fx -= resolution.x() * 0.5f; fx /= zoom; fx += screen_center.x() * resolution.x();
-	fy -= resolution.y() * 0.5f; fy /= zoom; fy += screen_center.y() * resolution.y();
+	fx -= resolution.x * 0.5f; fx /= zoom; fx += screen_center.x * resolution.x;
+	fy -= resolution.y * 0.5f; fy /= zoom; fy += screen_center.y * resolution.y;
 
-	float u = (fx - resolution.x() * 0.5f) * scale + image_resolution.x() * 0.5f;
-	float v = (fy - resolution.y() * 0.5f) * scale + image_resolution.y() * 0.5f;
+	float u = (fx - resolution.x * 0.5f) * scale + image_resolution.x * 0.5f;
+	float v = (fy - resolution.y * 0.5f) * scale + image_resolution.y * 0.5f;
 
 	int srcx = floorf(u);
 	int srcy = floorf(v);
-	uint32_t idx = x + resolution.x() * y;
-	uint32_t srcidx = srcx + image_resolution.x() * srcy;
+	uint32_t srcidx = srcx + image_resolution.x * srcy;
 
-	Array4f color;
-	if (srcx >= image_resolution.x() || srcy >= image_resolution.y() || srcx < 0 || srcy < 0) {
+	vec4 color;
+	if (srcx >= image_resolution.x || srcy >= image_resolution.y || srcx < 0 || srcy < 0) {
 		color = {0.0f, 0.0f, 0.0f, 0.0f};
 	} else {
 		float depth_value = depth[srcidx] * depth_scale;
-		Array3f c = colormap_turbo(depth_value);
+		vec3 c = colormap_turbo(depth_value);
 		color = {c[0], c[1], c[2], 1.0f};
 	}
 
-	Array4f prev_color;
+	vec4 prev_color;
 	surf2Dread((float4*)&prev_color, surface, x * sizeof(float4), y);
 	color = color * alpha + prev_color * (1.f-alpha);
 	surf2Dwrite(to_float4(color), surface, x * sizeof(float4), y);
 }
 
-__device__ Array3f colormap_viridis(float x) {
-	const Array3f c0 = Array3f{0.2777273272234177f, 0.005407344544966578f, 0.3340998053353061f};
-	const Array3f c1 = Array3f{0.1050930431085774f, 1.404613529898575f, 1.384590162594685f};
-	const Array3f c2 = Array3f{-0.3308618287255563f, 0.214847559468213f, 0.09509516302823659f};
-	const Array3f c3 = Array3f{-4.634230498983486f, -5.799100973351585f, -19.33244095627987f};
-	const Array3f c4 = Array3f{6.228269936347081f, 14.17993336680509f, 56.69055260068105f};
-	const Array3f c5 = Array3f{4.776384997670288f, -13.74514537774601f, -65.35303263337234f};
-	const Array3f c6 = Array3f{-5.435455855934631f, 4.645852612178535f, 26.3124352495832f};
+__device__ vec3 colormap_viridis(float x) {
+	const vec3 c0 = vec3{0.2777273272234177f, 0.005407344544966578f, 0.3340998053353061f};
+	const vec3 c1 = vec3{0.1050930431085774f, 1.404613529898575f, 1.384590162594685f};
+	const vec3 c2 = vec3{-0.3308618287255563f, 0.214847559468213f, 0.09509516302823659f};
+	const vec3 c3 = vec3{-4.634230498983486f, -5.799100973351585f, -19.33244095627987f};
+	const vec3 c4 = vec3{6.228269936347081f, 14.17993336680509f, 56.69055260068105f};
+	const vec3 c5 = vec3{4.776384997670288f, -13.74514537774601f, -65.35303263337234f};
+	const vec3 c6 = vec3{-5.435455855934631f, 4.645852612178535f, 26.3124352495832f};
 	x = __saturatef(x);
 	return (c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6))))));
 }
 
-__global__ void overlay_false_color_kernel(Vector2i resolution, Vector2i training_resolution, bool to_srgb, int fov_axis, cudaSurfaceObject_t surface, const float *error_map, Vector2i error_map_resolution, const float *average, float brightness, bool viridis) {
+__global__ void overlay_false_color_kernel(ivec2 resolution, ivec2 training_resolution, bool to_srgb, int fov_axis, cudaSurfaceObject_t surface, const float *error_map, ivec2 error_map_resolution, const float *average, float brightness, bool viridis) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
 	float error_map_scale = brightness/(0.0000001f+average[0]); // average maps to 1/16th
 
 	float scale = training_resolution[fov_axis] / float(resolution[fov_axis]);
-	float u = (x+0.5f-resolution.x()*0.5f) * scale + training_resolution.x()*0.5f;
-	float v = (y+0.5f-resolution.y()*0.5f) * scale + training_resolution.y()*0.5f;
-	int srcx = floorf(u * error_map_resolution.x() / float(max(1.f, (float)training_resolution.x())));
-	int srcy = floorf(v * error_map_resolution.y() / float(max(1.f, (float)training_resolution.y())));
+	float u = (x+0.5f-resolution.x*0.5f) * scale + training_resolution.x*0.5f;
+	float v = (y+0.5f-resolution.y*0.5f) * scale + training_resolution.y*0.5f;
+	int srcx = floorf(u * error_map_resolution.x / float(max(1.f, (float)training_resolution.x)));
+	int srcy = floorf(v * error_map_resolution.y / float(max(1.f, (float)training_resolution.y)));
 
-	uint32_t idx = x + resolution.x() * y;
-	uint32_t srcidx = srcx + error_map_resolution.x() * srcy;
+	uint32_t srcidx = srcx + error_map_resolution.x * srcy;
 
-	if (srcx >= error_map_resolution.x() || srcy >= error_map_resolution.y() || srcx<0 || srcy<0) {
+	if (srcx >= error_map_resolution.x || srcy >= error_map_resolution.y || srcx<0 || srcy<0) {
 		return;
 	}
 
@@ -523,60 +517,60 @@ __global__ void overlay_false_color_kernel(Vector2i resolution, Vector2i trainin
 	if (viridis) {
 		err *= 1.f / (1.f+err);
 	}
-	Array4f color;
+	vec4 color;
 	surf2Dread((float4*)&color, surface, x * sizeof(float4), y);
-	Array3f c = viridis ? colormap_viridis(err) : colormap_turbo(err);
-	float grey = color.x() * 0.2126f + color.y() * 0.7152f + color.z() * 0.0722f;
-	color.x() = grey*__saturatef(c.x());
-	color.y() = grey*__saturatef(c.y());
-	color.z() = grey*__saturatef(c.z());
+	vec3 c = viridis ? colormap_viridis(err) : colormap_turbo(err);
+	float grey = color.x * 0.2126f + color.y * 0.7152f + color.z * 0.0722f;
+	color.x = grey*__saturatef(c.x);
+	color.y = grey*__saturatef(c.y);
+	color.z = grey*__saturatef(c.z);
 
 	surf2Dwrite(to_float4(color), surface, x * sizeof(float4), y);
 }
 
-__global__ void tonemap_kernel(Vector2i resolution, float exposure, Array4f background_color, Array4f* accumulate_buffer, EColorSpace color_space, EColorSpace output_color_space, ETonemapCurve tonemap_curve, bool clamp_output_color, bool unmultiply_alpha, cudaSurfaceObject_t surface) {
+__global__ void tonemap_kernel(ivec2 resolution, float exposure, vec4 background_color, vec4* accumulate_buffer, EColorSpace color_space, EColorSpace output_color_space, ETonemapCurve tonemap_curve, bool clamp_output_color, bool unmultiply_alpha, cudaSurfaceObject_t surface) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
-	uint32_t idx = x + resolution.x() * y;
+	uint32_t idx = x + resolution.x * y;
 
 	// The background color is represented in SRGB, so convert
 	// to linear if that's not the space in which we're rendering.
 	if (color_space != EColorSpace::SRGB) {
-		background_color.head<3>() = srgb_to_linear(background_color.head<3>());
+		background_color.rgb = srgb_to_linear(background_color.rgb);
 	}
 
-	Array4f color = accumulate_buffer[idx];
-	float weight = (1 - color.w()) * background_color.w();
-	color.head<3>() += background_color.head<3>() * weight;
-	color.w() += weight;
+	vec4 color = accumulate_buffer[idx];
+	float weight = (1 - color.a) * background_color.a;
+	color.rgb += background_color.rgb * weight;
+	color.a += weight;
 
-	color.head<3>() = tonemap(color.head<3>(), Array3f::Constant(exposure), tonemap_curve, color_space, output_color_space);
+	color.rgb = tonemap(color.rgb, vec3(exposure), tonemap_curve, color_space, output_color_space);
 
-	if (unmultiply_alpha && color.w() > 0.0f) {
-		color.head<3>() /= color.w();
+	if (unmultiply_alpha && color.a > 0.0f) {
+		color.rgb = color.rgb() / color.a;
 	}
 
 	if (clamp_output_color) {
-		color = color.cwiseMax(0.0f).cwiseMin(1.0f);
+		color = clamp(color, vec4(0.0f), vec4(1.0f));
 	}
 
 	surf2Dwrite(to_float4(color), surface, x * sizeof(float4), y);
 }
 
 __global__ void dlss_splat_kernel(
-	Vector2i resolution,
+	ivec2 resolution,
 	cudaSurfaceObject_t dlss_surface,
 	cudaSurfaceObject_t surface
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
@@ -587,12 +581,11 @@ __global__ void dlss_splat_kernel(
 	color.x *= color.w;
 	color.y *= color.w;
 	color.z *= color.w;
-
 	surf2Dwrite(color, surface, x * sizeof(float4), y);
 }
 
 __global__ void depth_splat_kernel(
-	Vector2i resolution,
+	ivec2 resolution,
 	float znear,
 	float zfar,
 	float* __restrict__ depth_buffer,
@@ -601,30 +594,30 @@ __global__ void depth_splat_kernel(
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
-	uint32_t idx = x + resolution.x() * y;
+	uint32_t idx = x + resolution.x * y;
 	surf2Dwrite(to_ndc_depth(depth_buffer[idx], znear, zfar), surface, x * sizeof(float), y);
 }
 
 void CudaRenderBufferView::clear(cudaStream_t stream) const {
-	size_t n_pixels = resolution.prod();
-	CUDA_CHECK_THROW(cudaMemsetAsync(frame_buffer, 0, n_pixels * sizeof(Array4f), stream));
+	size_t n_pixels = compMul(resolution);
+	CUDA_CHECK_THROW(cudaMemsetAsync(frame_buffer, 0, n_pixels * sizeof(vec4), stream));
 	CUDA_CHECK_THROW(cudaMemsetAsync(depth_buffer, 0, n_pixels * sizeof(float), stream));
 }
 
-void CudaRenderBuffer::resize(const Vector2i& res) {
+void CudaRenderBuffer::resize(const ivec2& res) {
 	m_in_resolution = res;
-	m_frame_buffer.enlarge(res.x() * res.y());
-	m_depth_buffer.enlarge(res.x() * res.y());
+	m_frame_buffer.enlarge(res.x * res.y);
+	m_depth_buffer.enlarge(res.x * res.y);
 	if (m_depth_target) {
 		m_depth_target->resize(res, 1);
 	}
-	m_accumulate_buffer.enlarge(res.x() * res.y());
+	m_accumulate_buffer.enlarge(res.x * res.y);
 
-	Vector2i out_res = m_dlss ? m_dlss->out_resolution() : res;
+	ivec2 out_res = m_dlss ? m_dlss->out_resolution() : res;
 	auto prev_out_res = out_resolution();
 	m_rgba_target->resize(out_res, 4);
 
@@ -638,7 +631,7 @@ void CudaRenderBuffer::clear_frame(cudaStream_t stream) {
 }
 
 void CudaRenderBuffer::accumulate(float exposure, cudaStream_t stream) {
-	Vector2i res = in_resolution();
+	ivec2 res = in_resolution();
 
 	uint32_t accum_spp = m_dlss ? 0 : m_spp;
 
@@ -647,7 +640,7 @@ void CudaRenderBuffer::accumulate(float exposure, cudaStream_t stream) {
 	}
 
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x, threads.x), div_round_up((uint32_t)res.y, threads.y), 1 };
 	accumulate_kernel<<<blocks, threads, 0, stream>>>(
 		res,
 		frame_buffer(),
@@ -659,12 +652,12 @@ void CudaRenderBuffer::accumulate(float exposure, cudaStream_t stream) {
 	++m_spp;
 }
 
-void CudaRenderBuffer::tonemap(float exposure, const Array4f& background_color, EColorSpace output_color_space, float znear, float zfar, bool snap_to_pixel_centers, cudaStream_t stream) {
+void CudaRenderBuffer::tonemap(float exposure, const vec4& background_color, EColorSpace output_color_space, float znear, float zfar, bool snap_to_pixel_centers, cudaStream_t stream) {
 	assert(m_dlss || out_resolution() == in_resolution());
 
 	auto res = in_resolution();
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x, threads.x), div_round_up((uint32_t)res.y, threads.y), 1 };
 	tonemap_kernel<<<blocks, threads, 0, stream>>>(
 		res,
 		exposure,
@@ -688,12 +681,12 @@ void CudaRenderBuffer::tonemap(float exposure, const Array4f& background_color, 
 			res,
 			output_color_space == EColorSpace::Linear, /* HDR mode */
 			m_dlss_sharpening,
-			Vector2f::Constant(0.5f) - ld_random_pixel_offset(snap_to_pixel_centers ? 0 : sample_index), /* jitter offset in [-0.5, 0.5] */
+			vec2(0.5f) - ld_random_pixel_offset(snap_to_pixel_centers ? 0 : sample_index), /* jitter offset in [-0.5, 0.5] */
 			sample_index == 0 /* reset history */
 		);
 
 		auto out_res = out_resolution();
-		const dim3 out_blocks = { div_round_up((uint32_t)out_res.x(), threads.x), div_round_up((uint32_t)out_res.y(), threads.y), 1 };
+		const dim3 out_blocks = { div_round_up((uint32_t)out_res.x, threads.x), div_round_up((uint32_t)out_res.y, threads.y), 1 };
 		dlss_splat_kernel<<<out_blocks, threads, 0, stream>>>(out_res, m_dlss->output(), surface());
 	}
 
@@ -704,20 +697,20 @@ void CudaRenderBuffer::tonemap(float exposure, const Array4f& background_color, 
 
 void CudaRenderBuffer::overlay_image(
 	float alpha,
-	const Eigen::Array3f& exposure,
-	const Array4f& background_color,
+	const vec3& exposure,
+	const vec4& background_color,
 	EColorSpace output_color_space,
 	const void* __restrict__ image,
 	EImageDataType image_data_type,
-	const Vector2i& image_resolution,
+	const ivec2& image_resolution,
 	int fov_axis,
 	float zoom,
-	const Eigen::Vector2f& screen_center,
+	const vec2& screen_center,
 	cudaStream_t stream
 ) {
 	auto res = out_resolution();
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x, threads.x), div_round_up((uint32_t)res.y, threads.y), 1 };
 	overlay_image_kernel<<<blocks, threads, 0, stream>>>(
 		res,
 		alpha,
@@ -740,15 +733,15 @@ void CudaRenderBuffer::overlay_depth(
 	float alpha,
 	const float* __restrict__ depth,
 	float depth_scale,
-	const Vector2i& image_resolution,
+	const ivec2& image_resolution,
 	int fov_axis,
 	float zoom,
-	const Eigen::Vector2f& screen_center,
+	const vec2& screen_center,
 	cudaStream_t stream
 ) {
 	auto res = out_resolution();
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x, threads.x), div_round_up((uint32_t)res.y, threads.y), 1 };
 	overlay_depth_kernel<<<blocks, threads, 0, stream>>>(
 		res,
 		alpha,
@@ -762,10 +755,10 @@ void CudaRenderBuffer::overlay_depth(
 	);
 }
 
-void CudaRenderBuffer::overlay_false_color(Vector2i training_resolution, bool to_srgb, int fov_axis, cudaStream_t stream, const float* error_map, Vector2i error_map_resolution, const float* average, float brightness, bool viridis) {
+void CudaRenderBuffer::overlay_false_color(ivec2 training_resolution, bool to_srgb, int fov_axis, cudaStream_t stream, const float* error_map, ivec2 error_map_resolution, const float* average, float brightness, bool viridis) {
 	auto res = out_resolution();
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res.x(), threads.x), div_round_up((uint32_t)res.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)res.x, threads.x), div_round_up((uint32_t)res.y, threads.y), 1 };
 	overlay_false_color_kernel<<<blocks, threads, 0, stream>>>(
 		res,
 		training_resolution,
@@ -780,7 +773,7 @@ void CudaRenderBuffer::overlay_false_color(Vector2i training_resolution, bool to
 	);
 }
 
-void CudaRenderBuffer::enable_dlss(IDlssProvider& dlss_provider, const Eigen::Vector2i& max_out_res) {
+void CudaRenderBuffer::enable_dlss(IDlssProvider& dlss_provider, const ivec2& max_out_res) {
 #ifdef NGP_VULKAN
 	if (!m_dlss || m_dlss->max_out_resolution() != max_out_res) {
 		m_dlss = dlss_provider.init_dlss(max_out_res);

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -16,6 +16,7 @@
 #include <neural-graphics-primitives/common_device.cuh>
 #include <neural-graphics-primitives/common.h>
 #include <neural-graphics-primitives/envmap.cuh>
+#include <neural-graphics-primitives/json_binding.h>
 #include <neural-graphics-primitives/marching_cubes.h>
 #include <neural-graphics-primitives/nerf_loader.h>
 #include <neural-graphics-primitives/nerf_network.h>
@@ -25,6 +26,7 @@
 #include <neural-graphics-primitives/triangle_octree.cuh>
 
 #include <tiny-cuda-nn/encodings/grid.h>
+#include <tiny-cuda-nn/encodings/spherical_harmonics.h>
 #include <tiny-cuda-nn/loss.h>
 #include <tiny-cuda-nn/network_with_input_encoding.h>
 #include <tiny-cuda-nn/network.h>
@@ -34,11 +36,11 @@
 #include <filesystem/directory.h>
 #include <filesystem/path.h>
 
+
 #ifdef copysign
 #undef copysign
 #endif
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
@@ -55,7 +57,7 @@ inline constexpr __device__ float MAX_CONE_STEPSIZE() { return STEPSIZE() * (1<<
 
 // Used to index into the PRNG stream. Must be larger than the number of
 // samples consumed by any given training ray.
-inline constexpr __device__ uint32_t N_MAX_RANDOM_SAMPLES_PER_RAY() { return 8; }
+inline constexpr __device__ uint32_t N_MAX_RANDOM_SAMPLES_PER_RAY() { return 16; }
 
 // Any alpha below this is considered "invisible" and is thus culled away.
 inline constexpr __device__ float NERF_MIN_OPTICAL_THICKNESS() { return 0.01f; }
@@ -77,7 +79,7 @@ inline __host__ __device__ uint32_t grid_mip_offset(uint32_t mip) {
 	return NERF_GRID_N_CELLS() * mip;
 }
 
-inline __host__ __device__ float calc_cone_angle(float cosine, const Eigen::Vector2f& focal_length, float cone_angle_constant) {
+inline __host__ __device__ float calc_cone_angle(float cosine, const vec2& focal_length, float cone_angle_constant) {
 	// Pixel size. Doesn't always yield a good performance vs. quality
 	// trade off. Especially if training pixels have a much different
 	// size than rendering pixels.
@@ -86,13 +88,61 @@ inline __host__ __device__ float calc_cone_angle(float cosine, const Eigen::Vect
 	return cone_angle_constant;
 }
 
+inline __host__ __device__ float to_stepping_space(float t, float cone_angle) {
+	if (cone_angle <= 1e-5f) {
+		return t / MIN_CONE_STEPSIZE();
+	}
+
+	float log1p_c = logf(1.0f + cone_angle);
+
+	float a = (logf(MIN_CONE_STEPSIZE()) - logf(log1p_c)) / log1p_c;
+	float b = (logf(MAX_CONE_STEPSIZE()) - logf(log1p_c)) / log1p_c;
+
+	float at = expf(a * log1p_c);
+	float bt = expf(b * log1p_c);
+
+	if (t <= at) {
+		return (t - at) / MIN_CONE_STEPSIZE() + a;
+	} else if (t <= bt) {
+		return logf(t) / log1p_c;
+	} else {
+		return (t - bt) / MAX_CONE_STEPSIZE() + b;
+	}
+}
+
+inline __host__ __device__ float from_stepping_space(float n, float cone_angle) {
+	if (cone_angle <= 1e-5f) {
+		return n * MIN_CONE_STEPSIZE();
+	}
+
+	float log1p_c = logf(1.0f + cone_angle);
+
+	float a = (logf(MIN_CONE_STEPSIZE()) - logf(log1p_c)) / log1p_c;
+	float b = (logf(MAX_CONE_STEPSIZE()) - logf(log1p_c)) / log1p_c;
+
+	float at = expf(a * log1p_c);
+	float bt = expf(b * log1p_c);
+
+	if (n <= a) {
+		return (n - a) * MIN_CONE_STEPSIZE() + at;
+	} else if (n <= b) {
+		return expf(n * log1p_c);
+	} else {
+		return (n - b) * MAX_CONE_STEPSIZE() + bt;
+	}
+}
+
+inline __host__ __device__ float advance_n_steps(float t, float cone_angle, float n) {
+	return from_stepping_space(to_stepping_space(t, cone_angle) + n, cone_angle);
+}
+
 inline __host__ __device__ float calc_dt(float t, float cone_angle) {
-	return tcnn::clamp(t*cone_angle, MIN_CONE_STEPSIZE(), MAX_CONE_STEPSIZE());
+	return advance_n_steps(t, cone_angle, 1.0f) - t;
 }
 
 struct LossAndGradient {
-	Eigen::Array3f loss;
-	Eigen::Array3f gradient;
+	vec3 loss;
+	vec3 gradient;
 
 	__host__ __device__ LossAndGradient operator*(float scalar) {
 		return {loss * scalar, gradient * scalar};
@@ -103,108 +153,104 @@ struct LossAndGradient {
 	}
 };
 
-inline __device__ Array3f copysign(const Array3f& a, const Array3f& b) {
+inline __device__ vec3 copysign(const vec3& a, const vec3& b) {
 	return {
-		copysignf(a.x(), b.x()),
-		copysignf(a.y(), b.y()),
-		copysignf(a.z(), b.z()),
+		copysignf(a.x, b.x),
+		copysignf(a.y, b.y),
+		copysignf(a.z, b.z),
 	};
 }
 
-inline __device__ LossAndGradient l2_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
+inline __device__ LossAndGradient l2_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
 	return {
 		difference * difference,
 		2.0f * difference
 	};
 }
 
-inline __device__ LossAndGradient relative_l2_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
-	Array3f factor = (prediction * prediction + Array3f::Constant(1e-2f)).inverse();
+inline __device__ LossAndGradient relative_l2_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
+	vec3 denom = prediction * prediction + vec3(1e-2f);
 	return {
-		difference * difference * factor,
-		2.0f * difference * factor
+		difference * difference / denom,
+		2.0f * difference / denom
 	};
 }
 
-inline __device__ LossAndGradient l1_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
+inline __device__ LossAndGradient l1_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
 	return {
-		difference.abs(),
-		copysign(Array3f::Ones(), difference),
+		abs(difference),
+		copysign(vec3(1.0f), difference),
 	};
 }
 
-inline __device__ LossAndGradient huber_loss(const Array3f& target, const Array3f& prediction, float alpha = 1) {
-	Array3f difference = prediction - target;
-	Array3f abs_diff = difference.abs();
-	Array3f square = 0.5f/alpha * difference * difference;
+inline __device__ LossAndGradient huber_loss(const vec3& target, const vec3& prediction, float alpha = 1) {
+	vec3 difference = prediction - target;
+	vec3 abs_diff = abs(difference);
+	vec3 square = 0.5f/alpha * difference * difference;
 	return {
 		{
-			abs_diff.x() > alpha ? (abs_diff.x() - 0.5f * alpha) : square.x(),
-			abs_diff.y() > alpha ? (abs_diff.y() - 0.5f * alpha) : square.y(),
-			abs_diff.z() > alpha ? (abs_diff.z() - 0.5f * alpha) : square.z(),
+			abs_diff.x > alpha ? (abs_diff.x - 0.5f * alpha) : square.x,
+			abs_diff.y > alpha ? (abs_diff.y - 0.5f * alpha) : square.y,
+			abs_diff.z > alpha ? (abs_diff.z - 0.5f * alpha) : square.z,
 		},
 		{
-			abs_diff.x() > alpha ? (difference.x() > 0 ? 1.0f : -1.0f) : (difference.x() / alpha),
-			abs_diff.y() > alpha ? (difference.y() > 0 ? 1.0f : -1.0f) : (difference.y() / alpha),
-			abs_diff.z() > alpha ? (difference.z() > 0 ? 1.0f : -1.0f) : (difference.z() / alpha),
+			abs_diff.x > alpha ? (difference.x > 0 ? 1.0f : -1.0f) : (difference.x / alpha),
+			abs_diff.y > alpha ? (difference.y > 0 ? 1.0f : -1.0f) : (difference.y / alpha),
+			abs_diff.z > alpha ? (difference.z > 0 ? 1.0f : -1.0f) : (difference.z / alpha),
 		},
 	};
 }
 
-inline __device__ LossAndGradient log_l1_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
-	Array3f divisor = difference.abs() + Array3f::Ones();
+inline __device__ LossAndGradient log_l1_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
+	vec3 divisor = abs(difference) + vec3(1.0f);
 	return {
-		divisor.log(),
-		copysign(divisor.inverse(), difference),
+		log(divisor),
+		copysign(vec3(1.0f) / divisor, difference),
 	};
 }
 
-inline __device__ LossAndGradient smape_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
-	Array3f factor = (0.5f * (prediction.abs() + target.abs()) + Array3f::Constant(1e-2f)).inverse();
+inline __device__ LossAndGradient smape_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
+	vec3 denom = 0.5f * (abs(prediction) + abs(target)) + vec3(1e-2f);
 	return {
-		difference.abs() * factor,
-		copysign(factor, difference),
+		abs(difference) / denom,
+		copysign(vec3(1.0f) / denom, difference),
 	};
 }
 
-inline __device__ LossAndGradient mape_loss(const Array3f& target, const Array3f& prediction) {
-	Array3f difference = prediction - target;
-	Array3f factor = (prediction.abs() + Array3f::Constant(1e-2f)).inverse();
+inline __device__ LossAndGradient mape_loss(const vec3& target, const vec3& prediction) {
+	vec3 difference = prediction - target;
+	vec3 denom = abs(prediction) + vec3(1e-2f);
 	return {
-		difference.abs() * factor,
-		copysign(factor, difference),
+		abs(difference) / denom,
+		copysign(vec3(1.0f) / denom, difference),
 	};
 }
 
-inline __device__ float distance_to_next_voxel(const Vector3f& pos, const Vector3f& dir, const Vector3f& idir, float res) { // dda like step
-	Vector3f p = res * (pos - Vector3f::Constant(0.5f));
-	float tx = (floorf(p.x() + 0.5f + 0.5f * sign(dir.x())) - p.x()) * idir.x();
-	float ty = (floorf(p.y() + 0.5f + 0.5f * sign(dir.y())) - p.y()) * idir.y();
-	float tz = (floorf(p.z() + 0.5f + 0.5f * sign(dir.z())) - p.z()) * idir.z();
+inline __device__ float distance_to_next_voxel(const vec3& pos, const vec3& dir, const vec3& idir, float res) { // dda like step
+	vec3 p = res * (pos - vec3(0.5f));
+	float tx = (floorf(p.x + 0.5f + 0.5f * sign(dir.x)) - p.x) * idir.x;
+	float ty = (floorf(p.y + 0.5f + 0.5f * sign(dir.y)) - p.y) * idir.y;
+	float tz = (floorf(p.z + 0.5f + 0.5f * sign(dir.z)) - p.z) * idir.z;
 	float t = min(min(tx, ty), tz);
 
 	return fmaxf(t / res, 0.0f);
 }
 
-inline __device__ float advance_to_next_voxel(float t, float cone_angle, const Vector3f& pos, const Vector3f& dir, const Vector3f& idir, uint32_t mip) {
+inline __device__ float advance_to_next_voxel(float t, float cone_angle, const vec3& pos, const vec3& dir, const vec3& idir, uint32_t mip) {
 	float res = scalbnf(NERF_GRIDSIZE(), -(int)mip);
 
-	// Analytic stepping by a multiple of dt. Make empty space unequal to non-empty space
-	// due to the different stepping.
-	// float dt = calc_dt(t, cone_angle);
-	// return t + ceilf(fmaxf(distance_to_next_voxel(pos, dir, idir, res) / dt, 0.5f)) * dt;
-
-	// Regular stepping (may be slower but matches non-empty space)
 	float t_target = t + distance_to_next_voxel(pos, dir, idir, res);
-	do {
-		t += calc_dt(t, cone_angle);
-	} while (t < t_target);
-	return t;
+
+	// Analytic stepping in multiples of 1 in the "log-space" of our exponential stepping routine
+	t = to_stepping_space(t, cone_angle);
+	t_target = to_stepping_space(t_target, cone_angle);
+
+	return from_stepping_space(t + ceilf(fmaxf(t_target - t, 0.5f)), cone_angle);
 }
 
 __device__ float network_to_rgb(float val, ENerfActivation activation) {
@@ -229,6 +275,15 @@ __device__ float network_to_rgb_derivative(float val, ENerfActivation activation
 	return 0.0f;
 }
 
+template <typename T>
+__device__ vec3 network_to_rgb_derivative_vec(const T& val, ENerfActivation activation) {
+	return {
+		network_to_rgb_derivative(float(val[0]), activation),
+		network_to_rgb_derivative(float(val[1]), activation),
+		network_to_rgb_derivative(float(val[2]), activation),
+	};
+}
+
 __device__ float network_to_density(float val, ENerfActivation activation) {
 	switch (activation) {
 		case ENerfActivation::None: return val;
@@ -251,53 +306,54 @@ __device__ float network_to_density_derivative(float val, ENerfActivation activa
 	return 0.0f;
 }
 
-__device__ Array3f network_to_rgb(const tcnn::vector_t<tcnn::network_precision_t, 4>& local_network_output, ENerfActivation activation) {
+template <typename T>
+__device__ vec3 network_to_rgb_vec(const T& val, ENerfActivation activation) {
 	return {
-		network_to_rgb(float(local_network_output[0]), activation),
-		network_to_rgb(float(local_network_output[1]), activation),
-		network_to_rgb(float(local_network_output[2]), activation)
+		network_to_rgb(float(val[0]), activation),
+		network_to_rgb(float(val[1]), activation),
+		network_to_rgb(float(val[2]), activation),
 	};
 }
 
-__device__ Vector3f warp_position(const Vector3f& pos, const BoundingBox& aabb) {
-	// return {tcnn::logistic(pos.x() - 0.5f), tcnn::logistic(pos.y() - 0.5f), tcnn::logistic(pos.z() - 0.5f)};
+__device__ vec3 warp_position(const vec3& pos, const BoundingBox& aabb) {
+	// return {tcnn::logistic(pos.x - 0.5f), tcnn::logistic(pos.y - 0.5f), tcnn::logistic(pos.z - 0.5f)};
 	// return pos;
 
 	return aabb.relative_pos(pos);
 }
 
-__device__ Vector3f unwarp_position(const Vector3f& pos, const BoundingBox& aabb) {
-	// return {logit(pos.x()) + 0.5f, logit(pos.y()) + 0.5f, logit(pos.z()) + 0.5f};
+__device__ vec3 unwarp_position(const vec3& pos, const BoundingBox& aabb) {
+	// return {logit(pos.x) + 0.5f, logit(pos.y) + 0.5f, logit(pos.z) + 0.5f};
 	// return pos;
 
-	return aabb.min + pos.cwiseProduct(aabb.diag());
+	return aabb.min + pos * aabb.diag();
 }
 
-__device__ Vector3f unwarp_position_derivative(const Vector3f& pos, const BoundingBox& aabb) {
-	// return {logit(pos.x()) + 0.5f, logit(pos.y()) + 0.5f, logit(pos.z()) + 0.5f};
+__device__ vec3 unwarp_position_derivative(const vec3& pos, const BoundingBox& aabb) {
+	// return {logit(pos.x) + 0.5f, logit(pos.y) + 0.5f, logit(pos.z) + 0.5f};
 	// return pos;
 
 	return aabb.diag();
 }
 
-__device__ Vector3f warp_position_derivative(const Vector3f& pos, const BoundingBox& aabb) {
-	return unwarp_position_derivative(pos, aabb).cwiseInverse();
+__device__ vec3 warp_position_derivative(const vec3& pos, const BoundingBox& aabb) {
+	return vec3(1.0f) / unwarp_position_derivative(pos, aabb);
 }
 
-__host__ __device__ Vector3f warp_direction(const Vector3f& dir) {
-	return (dir + Vector3f::Ones()) * 0.5f;
+__host__ __device__ vec3 warp_direction(const vec3& dir) {
+	return (dir + vec3(1.0f)) * 0.5f;
 }
 
-__device__ Vector3f unwarp_direction(const Vector3f& dir) {
-	return dir * 2.0f - Vector3f::Ones();
+__device__ vec3 unwarp_direction(const vec3& dir) {
+	return dir * 2.0f - vec3(1.0f);
 }
 
-__device__ Vector3f warp_direction_derivative(const Vector3f& dir) {
-	return Vector3f::Constant(0.5f);
+__device__ vec3 warp_direction_derivative(const vec3& dir) {
+	return vec3(0.5f);
 }
 
-__device__ Vector3f unwarp_direction_derivative(const Vector3f& dir) {
-	return Vector3f::Constant(2.0f);
+__device__ vec3 unwarp_direction_derivative(const vec3& dir) {
+	return vec3(2.0f);
 }
 
 __device__ float warp_dt(float dt) {
@@ -310,39 +366,42 @@ __device__ float unwarp_dt(float dt) {
 	return dt * (max_stepsize - MIN_CONE_STEPSIZE()) + MIN_CONE_STEPSIZE();
 }
 
-__device__ uint32_t cascaded_grid_idx_at(Vector3f pos, uint32_t mip) {
+__device__ uint32_t cascaded_grid_idx_at(vec3 pos, uint32_t mip) {
 	float mip_scale = scalbnf(1.0f, -mip);
-	pos -= Vector3f::Constant(0.5f);
+	pos -= vec3(0.5f);
 	pos *= mip_scale;
-	pos += Vector3f::Constant(0.5f);
+	pos += vec3(0.5f);
 
-	Vector3i i = (pos * NERF_GRIDSIZE()).cast<int>();
-
-	if (i.x() < -1 || i.x() > NERF_GRIDSIZE() || i.y() < -1 || i.y() > NERF_GRIDSIZE() || i.z() < -1 || i.z() > NERF_GRIDSIZE()) {
-		printf("WTF %d %d %d\n", i.x(), i.y(), i.z());
+	ivec3 i = pos * (float)NERF_GRIDSIZE();
+	if (i.x < 0 || i.x >= NERF_GRIDSIZE() || i.y < 0 || i.y >= NERF_GRIDSIZE() || i.z < 0 || i.z >= NERF_GRIDSIZE()) {
+		return 0xFFFFFFFF;
 	}
 
-	uint32_t idx = tcnn::morton3D(
-		tcnn::clamp(i.x(), 0, (int)NERF_GRIDSIZE()-1),
-		tcnn::clamp(i.y(), 0, (int)NERF_GRIDSIZE()-1),
-		tcnn::clamp(i.z(), 0, (int)NERF_GRIDSIZE()-1)
-	);
-
-	return idx;
+	return tcnn::morton3D(i.x, i.y, i.z);
 }
 
-__device__ bool density_grid_occupied_at(const Vector3f& pos, const uint8_t* density_grid_bitfield, uint32_t mip) {
+__device__ bool density_grid_occupied_at(const vec3& pos, const uint8_t* density_grid_bitfield, uint32_t mip) {
 	uint32_t idx = cascaded_grid_idx_at(pos, mip);
+	if (idx == 0xFFFFFFFF) {
+		return false;
+	}
 	return density_grid_bitfield[idx/8+grid_mip_offset(mip)/8] & (1<<(idx%8));
 }
 
-__device__ float cascaded_grid_at(Vector3f pos, const float* cascaded_grid, uint32_t mip) {
+__device__ float cascaded_grid_at(vec3 pos, const float* cascaded_grid, uint32_t mip) {
 	uint32_t idx = cascaded_grid_idx_at(pos, mip);
+	if (idx == 0xFFFFFFFF) {
+		return 0.0f;
+	}
 	return cascaded_grid[idx+grid_mip_offset(mip)];
 }
 
-__device__ float& cascaded_grid_at(Vector3f pos, float* cascaded_grid, uint32_t mip) {
+__device__ float& cascaded_grid_at(vec3 pos, float* cascaded_grid, uint32_t mip) {
 	uint32_t idx = cascaded_grid_idx_at(pos, mip);
+	if (idx == 0xFFFFFFFF) {
+		idx = 0;
+		printf("WARNING: invalid cascaded grid access.");
+	}
 	return cascaded_grid[idx+grid_mip_offset(mip)];
 }
 
@@ -378,17 +437,17 @@ __global__ void mark_untrained_density_grid(const uint32_t n_elements,  float* _
 	uint32_t z = tcnn::morton3D_invert(pos_idx>>2);
 
 	float voxel_size = scalbnf(1.0f / NERF_GRIDSIZE(), level);
-	Vector3f pos = (Vector3f{(float)x, (float)y, (float)z} / NERF_GRIDSIZE() - Vector3f::Constant(0.5f)) * scalbnf(1.0f, level) + Vector3f::Constant(0.5f);
+	vec3 pos = (vec3{(float)x, (float)y, (float)z} / (float)NERF_GRIDSIZE() - vec3(0.5f)) * scalbnf(1.0f, level) + vec3(0.5f);
 
-	Vector3f corners[8] = {
-		pos + Vector3f{0.0f,       0.0f,       0.0f      },
-		pos + Vector3f{voxel_size, 0.0f,       0.0f      },
-		pos + Vector3f{0.0f,       voxel_size, 0.0f      },
-		pos + Vector3f{voxel_size, voxel_size, 0.0f      },
-		pos + Vector3f{0.0f,       0.0f,       voxel_size},
-		pos + Vector3f{voxel_size, 0.0f,       voxel_size},
-		pos + Vector3f{0.0f,       voxel_size, voxel_size},
-		pos + Vector3f{voxel_size, voxel_size, voxel_size},
+	vec3 corners[8] = {
+		pos + vec3{0.0f,       0.0f,       0.0f      },
+		pos + vec3{voxel_size, 0.0f,       0.0f      },
+		pos + vec3{0.0f,       voxel_size, 0.0f      },
+		pos + vec3{voxel_size, voxel_size, 0.0f      },
+		pos + vec3{0.0f,       0.0f,       voxel_size},
+		pos + vec3{voxel_size, 0.0f,       voxel_size},
+		pos + vec3{0.0f,       voxel_size, voxel_size},
+		pos + vec3{voxel_size, voxel_size, voxel_size},
 	};
 
 	// Number of training views that need to see a voxel cell
@@ -411,18 +470,18 @@ __global__ void mark_untrained_density_grid(const uint32_t n_elements,  float* _
 
 		for (uint32_t k = 0; k < 8; ++k) {
 			// Only consider voxel corners in front of the camera
-			Vector3f dir = (corners[k] - xform.col(3)).normalized();
-			if (dir.dot(xform.col(2)) < 1e-4f) {
+			vec3 dir = normalize(corners[k] - xform[3]);
+			if (dot(dir, xform[2]) < 1e-4f) {
 				continue;
 			}
 
 			// Check if voxel corner projects onto the image plane, i.e. uv must be in (0, 1)^2
-			Vector2f uv = pos_to_uv(corners[k], m.resolution, m.focal_length, xform, m.principal_point, Vector3f::Zero(), {}, m.lens);
+			vec2 uv = pos_to_uv(corners[k], m.resolution, m.focal_length, xform, m.principal_point, vec3(0.0f), {}, m.lens);
 
 			// `pos_to_uv` is _not_ injective in the presence of lens distortion (which breaks down outside of the image plane).
 			// So we need to check whether the produced uv location generates a ray that matches the ray that we started with.
-			Ray ray = uv_to_ray(0.0f, uv, m.resolution, m.focal_length, xform, m.principal_point, Vector3f::Zero(), 0.0f, 1.0f, 0.0f, {}, {}, m.lens);
-			if ((ray.d.normalized() - dir).norm() < 1e-3f && uv.x() > 0.0f && uv.y() > 0.0f && uv.x() < 1.0f && uv.y() < 1.0f) {
+			Ray ray = uv_to_ray(0.0f, uv, m.resolution, m.focal_length, xform, m.principal_point, vec3(0.0f), 0.0f, 1.0f, 0.0f, {}, {}, m.lens);
+			if (distance(normalize(ray.d), dir) < 1e-3f && uv.x > 0.0f && uv.y > 0.0f && uv.x < 1.0f && uv.y < 1.0f) {
 				++count;
 				break;
 			}
@@ -434,52 +493,52 @@ __global__ void mark_untrained_density_grid(const uint32_t n_elements,  float* _
 	}
 }
 
-__global__ void generate_grid_samples_nerf_uniform(Eigen::Vector3i res_3d, const uint32_t step, BoundingBox render_aabb, Matrix3f render_aabb_to_local, BoundingBox train_aabb, NerfPosition* __restrict__ out) {
+__global__ void generate_grid_samples_nerf_uniform(ivec3 res_3d, const uint32_t step, BoundingBox render_aabb, mat3 render_aabb_to_local, BoundingBox train_aabb, NerfPosition* __restrict__ out) {
 	// check grid_in for negative values -> must be negative on output
 	uint32_t x = threadIdx.x + blockIdx.x * blockDim.x;
 	uint32_t y = threadIdx.y + blockIdx.y * blockDim.y;
 	uint32_t z = threadIdx.z + blockIdx.z * blockDim.z;
-	if (x >= res_3d.x() || y >= res_3d.y() || z >= res_3d.z()) {
+	if (x >= res_3d.x || y >= res_3d.y || z >= res_3d.z) {
 		return;
 	}
 
-	uint32_t i = x + y * res_3d.x() + z * res_3d.x() * res_3d.y();
-	Vector3f pos = Vector3f{(float)x, (float)y, (float)z}.cwiseQuotient((res_3d - Vector3i::Ones()).cast<float>());
-	pos = render_aabb_to_local.transpose() * (pos.cwiseProduct(render_aabb.max - render_aabb.min) + render_aabb.min);
+	uint32_t i = x + y * res_3d.x + z * res_3d.x * res_3d.y;
+	vec3 pos = vec3{(float)x, (float)y, (float)z} / vec3(res_3d - ivec3(1));
+	pos = transpose(render_aabb_to_local) * (pos * (render_aabb.max - render_aabb.min) + render_aabb.min);
 	out[i] = { warp_position(pos, train_aabb), warp_dt(MIN_CONE_STEPSIZE()) };
 }
 
 // generate samples for uniform grid including constant ray direction
-__global__ void generate_grid_samples_nerf_uniform_dir(Eigen::Vector3i res_3d, const uint32_t step, BoundingBox render_aabb, Matrix3f render_aabb_to_local, BoundingBox train_aabb, Eigen::Vector3f ray_dir, NerfCoordinate* __restrict__ network_input, bool voxel_centers) {
+__global__ void generate_grid_samples_nerf_uniform_dir(ivec3 res_3d, const uint32_t step, BoundingBox render_aabb, mat3 render_aabb_to_local, BoundingBox train_aabb, vec3 ray_dir, NerfCoordinate* __restrict__ network_input, bool voxel_centers) {
 	// check grid_in for negative values -> must be negative on output
 	uint32_t x = threadIdx.x + blockIdx.x * blockDim.x;
 	uint32_t y = threadIdx.y + blockIdx.y * blockDim.y;
 	uint32_t z = threadIdx.z + blockIdx.z * blockDim.z;
-	if (x >= res_3d.x() || y >= res_3d.y() || z >= res_3d.z()) {
+	if (x >= res_3d.x || y >= res_3d.y || z >= res_3d.z) {
 		return;
 	}
 
-	uint32_t i = x+ y*res_3d.x() + z*res_3d.x()*res_3d.y();
-	Vector3f pos;
+	uint32_t i = x+ y*res_3d.x + z*res_3d.x*res_3d.y;
+	vec3 pos;
 	if (voxel_centers) {
-		pos = Vector3f{(float)x + 0.5f, (float)y + 0.5f, (float)z + 0.5f}.cwiseQuotient((res_3d).cast<float>());
+		pos = vec3{(float)x + 0.5f, (float)y + 0.5f, (float)z + 0.5f} / vec3(res_3d);
 	} else {
-		pos = Vector3f{(float)x, (float)y, (float)z}.cwiseQuotient((res_3d - Vector3i::Ones()).cast<float>());
+		pos = vec3{(float)x, (float)y, (float)z} / vec3(res_3d - ivec3(1));
 	}
 
-	pos = render_aabb_to_local.transpose() * (pos.cwiseProduct(render_aabb.max - render_aabb.min) + render_aabb.min);
+	pos = transpose(render_aabb_to_local) * (pos * (render_aabb.max - render_aabb.min) + render_aabb.min);
 	network_input[i] = { warp_position(pos, train_aabb), warp_direction(ray_dir), warp_dt(MIN_CONE_STEPSIZE()) };
 }
 
-inline __device__ int mip_from_pos(const Vector3f& pos, uint32_t max_cascade = NERF_CASCADES()-1) {
+inline __device__ uint32_t mip_from_pos(const vec3& pos, uint32_t max_cascade = NERF_CASCADES()-1) {
 	int exponent;
-	float maxval = (pos - Vector3f::Constant(0.5f)).cwiseAbs().maxCoeff();
+	float maxval = compMax(abs(pos - vec3(0.5f)));
 	frexpf(maxval, &exponent);
-	return min(max_cascade, max(0, exponent+1));
+	return (uint32_t)tcnn::clamp(exponent+1, 0, (int)max_cascade);
 }
 
-inline __device__ int mip_from_dt(float dt, const Vector3f& pos, uint32_t max_cascade = NERF_CASCADES()-1) {
-	int mip = mip_from_pos(pos, max_cascade);
+inline __device__ uint32_t mip_from_dt(float dt, const vec3& pos, uint32_t max_cascade = NERF_CASCADES()-1) {
+	uint32_t mip = mip_from_pos(pos, max_cascade);
 	dt *= 2 * NERF_GRIDSIZE();
 	if (dt < 1.0f) {
 		return mip;
@@ -487,7 +546,7 @@ inline __device__ int mip_from_dt(float dt, const Vector3f& pos, uint32_t max_ca
 
 	int exponent;
 	frexpf(dt, &exponent);
-	return min(max_cascade, max(exponent, mip));
+	return (uint32_t)tcnn::clamp((int)mip, exponent, (int)max_cascade);
 }
 
 __global__ void generate_grid_samples_nerf_nonuniform(const uint32_t n_elements, default_rng_t rng, const uint32_t step, BoundingBox aabb, const float* __restrict__ grid_in, NerfPosition* __restrict__ out, uint32_t* __restrict__ indices, uint32_t n_cascades, float thresh) {
@@ -515,7 +574,7 @@ __global__ void generate_grid_samples_nerf_nonuniform(const uint32_t n_elements,
 	uint32_t y = tcnn::morton3D_invert(pos_idx>>1);
 	uint32_t z = tcnn::morton3D_invert(pos_idx>>2);
 
-	Vector3f pos = ((Vector3f{(float)x, (float)y, (float)z} + random_val_3d(rng)) / NERF_GRIDSIZE() - Vector3f::Constant(0.5f)) * scalbnf(1.0f, level) + Vector3f::Constant(0.5f);
+	vec3 pos = ((vec3{(float)x, (float)y, (float)z} + random_val_3d(rng)) / (float)NERF_GRIDSIZE() - vec3(0.5f)) * scalbnf(1.0f, level) + vec3(0.5f);
 
 	out[i] = { warp_position(pos, aabb), warp_dt(MIN_CONE_STEPSIZE()) };
 	indices[i] = idx;
@@ -548,7 +607,7 @@ __global__ void grid_samples_half_to_float(const uint32_t n_elements, BoundingBo
 	float mlp = float(network_output[i]);
 
 	if (grid_in) {
-		Vector3f pos = unwarp_position(coords_in[i].p, aabb);
+		vec3 pos = unwarp_position(coords_in[i].p, aabb);
 		float grid_density = cascaded_grid_at(pos, grid_in, mip_from_pos(pos, max_cascade));
 		if (grid_density < NERF_MIN_OPTICAL_THICKNESS()) {
 			mlp = -10000.0f;
@@ -638,68 +697,96 @@ __global__ void bitfield_max_pool(const uint32_t n_elements,
 	next_level[tcnn::morton3D(x, y, z)] |= bits;
 }
 
-__global__ void advance_pos_nerf(
+template <bool MIP_FROM_DT=false>
+__device__ float if_unoccupied_advance_to_next_occupied_voxel(
+	float t,
+	float cone_angle,
+	const Ray& ray,
+	const vec3& idir,
+	const uint8_t* __restrict__ density_grid,
+	uint32_t min_mip,
+	uint32_t max_mip,
+	BoundingBox aabb,
+	mat3 aabb_to_local = mat3(1.0f)
+) {
+	while (true) {
+		vec3 pos = ray(t);
+		if (t >= MAX_DEPTH() || !aabb.contains(aabb_to_local * pos)) {
+			return MAX_DEPTH();
+		}
+
+		uint32_t mip = tcnn::clamp(MIP_FROM_DT ? mip_from_dt(calc_dt(t, cone_angle), pos) : mip_from_pos(pos), min_mip, max_mip);
+
+		if (!density_grid || density_grid_occupied_at(pos, density_grid, mip)) {
+			return t;
+		}
+
+		// Find largest empty voxel surrounding us, such that we can advance as far as possible in the next step.
+		// Other places that do voxel stepping don't need this, because they don't rely on thread coherence as
+		// much as this one here.
+		while (mip < max_mip && !density_grid_occupied_at(pos, density_grid, mip+1)) {
+			++mip;
+		}
+
+		t = advance_to_next_voxel(t, cone_angle, pos, ray.d, idir, mip);
+	}
+}
+
+__device__ void advance_pos_nerf(
+	NerfPayload& payload,
+	const BoundingBox& render_aabb,
+	const mat3& render_aabb_to_local,
+	const vec3& camera_fwd,
+	const vec2& focal_length,
+	uint32_t sample_index,
+	const uint8_t* __restrict__ density_grid,
+	uint32_t min_mip,
+	uint32_t max_mip,
+	float cone_angle_constant
+) {
+	if (!payload.alive) {
+		return;
+	}
+
+	vec3 origin = payload.origin;
+	vec3 dir = payload.dir;
+	vec3 idir = vec3(1.0f) / dir;
+
+	float cone_angle = calc_cone_angle(dot(dir, camera_fwd), focal_length, cone_angle_constant);
+
+	float t = advance_n_steps(payload.t, cone_angle, ld_random_val(sample_index, payload.idx * 786433));
+	t = if_unoccupied_advance_to_next_occupied_voxel(t, cone_angle, {origin, dir}, idir, density_grid, min_mip, max_mip, render_aabb, render_aabb_to_local);
+	if (t >= MAX_DEPTH()) {
+		payload.alive = false;
+	} else {
+		payload.t = t;
+	}
+}
+
+__global__ void advance_pos_nerf_kernel(
 	const uint32_t n_elements,
 	BoundingBox render_aabb,
-	Matrix3f render_aabb_to_local,
-	Vector3f camera_fwd,
-	Vector2f focal_length,
+	mat3 render_aabb_to_local,
+	vec3 camera_fwd,
+	vec2 focal_length,
 	uint32_t sample_index,
 	NerfPayload* __restrict__ payloads,
 	const uint8_t* __restrict__ density_grid,
 	uint32_t min_mip,
+	uint32_t max_mip,
 	float cone_angle_constant
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 
-	NerfPayload& payload = payloads[i];
-
-	if (!payload.alive) {
-		return;
-	}
-
-	Vector3f origin = payload.origin;
-	Vector3f dir = payload.dir;
-	Vector3f idir = dir.cwiseInverse();
-
-	float cone_angle = calc_cone_angle(dir.dot(camera_fwd), focal_length, cone_angle_constant);
-
-	float t = payload.t;
-	float dt = calc_dt(t, cone_angle);
-	t += ld_random_val(sample_index, i * 786433) * dt;
-	Vector3f pos;
-
-	while (1) {
-		pos = origin + dir * t;
-		if (!render_aabb.contains(render_aabb_to_local * pos)) {
-			payload.alive = false;
-			break;
-		}
-
-		dt = calc_dt(t, cone_angle);
-
-		// Use the mip level from the position rather than dt. Unlike training,
-		// for rendering there's no need to use coarser mip levels when the step
-		// size is large (rather, it reduces performance, because the network may be queried)
-		// more frequently than necessary.
-		uint32_t mip = max(min_mip, mip_from_pos(pos));
-
-		if (!density_grid || density_grid_occupied_at(pos, density_grid, mip)) {
-			break;
-		}
-
-		t = advance_to_next_voxel(t, cone_angle, pos, dir, idir, mip);
-	}
-
-	payload.t = t;
+	advance_pos_nerf(payloads[i], render_aabb, render_aabb_to_local, camera_fwd, focal_length, sample_index, density_grid, min_mip, max_mip, cone_angle_constant);
 }
 
-__global__ void generate_nerf_network_inputs_from_positions(const uint32_t n_elements, BoundingBox aabb, const Vector3f* __restrict__ pos, PitchedPtr<NerfCoordinate> network_input, const float* extra_dims) {
+__global__ void generate_nerf_network_inputs_from_positions(const uint32_t n_elements, BoundingBox aabb, const vec3* __restrict__ pos, PitchedPtr<NerfCoordinate> network_input, const float* extra_dims) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 
-	Vector3f dir=(pos[i]-Vector3f::Constant(0.5f)).normalized(); // choose outward pointing directions, for want of a better choice
+	vec3 dir = normalize(pos[i] - vec3(0.5f)); // choose outward pointing directions, for want of a better choice
 	network_input(i)->set_with_optional_extra_dims(warp_position(pos[i], aabb), warp_direction(dir), warp_dt(MIN_CONE_STEPSIZE()), extra_dims, network_input.stride_in_bytes);
 }
 
@@ -707,43 +794,45 @@ __global__ void generate_nerf_network_inputs_at_current_position(const uint32_t 
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 
-	Vector3f dir = payloads[i].dir;
+	vec3 dir = payloads[i].dir;
 	network_input(i)->set_with_optional_extra_dims(warp_position(payloads[i].origin + dir * payloads[i].t, aabb), warp_direction(dir), warp_dt(MIN_CONE_STEPSIZE()), extra_dims, network_input.stride_in_bytes);
 }
 
-__global__ void compute_nerf_rgba(const uint32_t n_elements, Array4f* network_output, ENerfActivation rgb_activation, ENerfActivation density_activation, float depth, bool density_as_alpha = false) {
+__device__ vec4 compute_nerf_rgba(const vec4& network_output, ENerfActivation rgb_activation, ENerfActivation density_activation, float depth, bool density_as_alpha = false) {
+	vec4 rgba = network_output;
+
+	float density = network_to_density(rgba.a, density_activation);
+	float alpha = 1.f;
+	if (density_as_alpha) {
+		rgba.a = density;
+	} else {
+		rgba.a = alpha = tcnn::clamp(1.f - __expf(-density * depth), 0.0f, 1.0f);
+	}
+
+	rgba.rgb = network_to_rgb_vec(rgba.rgb, rgb_activation) * alpha;
+	return rgba;
+}
+
+__global__ void compute_nerf_rgba_kernel(const uint32_t n_elements, vec4* network_output, ENerfActivation rgb_activation, ENerfActivation density_activation, float depth, bool density_as_alpha = false) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 
-	Array4f rgba = network_output[i];
-
-	float density = network_to_density(rgba.w(), density_activation);
-	float alpha = 1.f;
-	if (density_as_alpha) {
-		rgba.w() = density;
-	} else {
-		rgba.w() = alpha = tcnn::clamp(1.f - __expf(-density * depth), 0.0f, 1.0f);
-	}
-
-	rgba.x() = network_to_rgb(rgba.x(), rgb_activation) * alpha;
-	rgba.y() = network_to_rgb(rgba.y(), rgb_activation) * alpha;
-	rgba.z() = network_to_rgb(rgba.z(), rgb_activation) * alpha;
-
-	network_output[i] = rgba;
+	network_output[i] = compute_nerf_rgba(network_output[i], rgb_activation, density_activation, depth, density_as_alpha);
 }
 
 __global__ void generate_next_nerf_network_inputs(
 	const uint32_t n_elements,
 	BoundingBox render_aabb,
-	Matrix3f render_aabb_to_local,
+	mat3 render_aabb_to_local,
 	BoundingBox train_aabb,
-	Vector2f focal_length,
-	Vector3f camera_fwd,
+	vec2 focal_length,
+	vec3 camera_fwd,
 	NerfPayload* __restrict__ payloads,
 	PitchedPtr<NerfCoordinate> network_input,
 	uint32_t n_steps,
 	const uint8_t* __restrict__ density_grid,
 	uint32_t min_mip,
+	uint32_t max_mip,
 	float cone_angle_constant,
 	const float* extra_dims
 ) {
@@ -756,40 +845,23 @@ __global__ void generate_next_nerf_network_inputs(
 		return;
 	}
 
-	Vector3f origin = payload.origin;
-	Vector3f dir = payload.dir;
-	Vector3f idir = dir.cwiseInverse();
+	vec3 origin = payload.origin;
+	vec3 dir = payload.dir;
+	vec3 idir = vec3(1.0f) / dir;
 
-	float cone_angle = calc_cone_angle(dir.dot(camera_fwd), focal_length, cone_angle_constant);
+	float cone_angle = calc_cone_angle(dot(dir, camera_fwd), focal_length, cone_angle_constant);
 
 	float t = payload.t;
 
 	for (uint32_t j = 0; j < n_steps; ++j) {
-		Vector3f pos;
-		float dt = 0.0f;
-		while (1) {
-			pos = origin + dir * t;
-			if (!render_aabb.contains(render_aabb_to_local * pos)) {
-				payload.n_steps = j;
-				return;
-			}
-
-			dt = calc_dt(t, cone_angle);
-
-			// Use the mip level from the position rather than dt. Unlike training,
-			// for rendering there's no need to use coarser mip levels when the step
-			// size is large (rather, it reduces performance, because the network may be queried)
-			// more frequently than necessary.
-			uint32_t mip = max(min_mip, mip_from_pos(pos));
-
-			if (!density_grid || density_grid_occupied_at(pos, density_grid, mip)) {
-				break;
-			}
-
-			t = advance_to_next_voxel(t, cone_angle, pos, dir, idir, mip);
+		t = if_unoccupied_advance_to_next_occupied_voxel(t, cone_angle, {origin, dir}, idir, density_grid, min_mip, max_mip, render_aabb, render_aabb_to_local);
+		if (t >= MAX_DEPTH()) {
+			payload.n_steps = j;
+			return;
 		}
 
-		network_input(i + j * n_elements)->set_with_optional_extra_dims(warp_position(pos, train_aabb), warp_direction(dir), warp_dt(dt), extra_dims, network_input.stride_in_bytes); // XXXCONE
+		float dt = calc_dt(t, cone_angle);
+		network_input(i + j * n_elements)->set_with_optional_extra_dims(warp_position(origin + dir * t, train_aabb), warp_direction(dir), warp_dt(dt), extra_dims, network_input.stride_in_bytes); // XXXCONE
 		t += dt;
 	}
 
@@ -804,10 +876,10 @@ __global__ void composite_kernel_nerf(
 	BoundingBox aabb,
 	float glow_y_cutoff,
 	int glow_mode,
-	Matrix<float, 3, 4> camera_matrix,
-	Vector2f focal_length,
+	mat4x3 camera_matrix,
+	vec2 focal_length,
 	float depth_scale,
-	Array4f* __restrict__ rgba,
+	vec4* __restrict__ rgba,
 	float* __restrict__ depth,
 	NerfPayload* payloads,
 	PitchedPtr<NerfCoordinate> network_input,
@@ -830,10 +902,10 @@ __global__ void composite_kernel_nerf(
 		return;
 	}
 
-	Array4f local_rgba = rgba[i];
+	vec4 local_rgba = rgba[i];
 	float local_depth = depth[i];
-	Vector3f origin = payload.origin;
-	Vector3f cam_fwd = camera_matrix.col(2);
+	vec3 origin = payload.origin;
+	vec3 cam_fwd = camera_matrix[2];
 	// Composite in the last n steps
 	uint32_t actual_n_steps = payload.n_steps;
 	uint32_t j = 0;
@@ -845,10 +917,10 @@ __global__ void composite_kernel_nerf(
 		local_network_output[2] = network_output[i + j * n_elements + 2 * stride];
 		local_network_output[3] = network_output[i + j * n_elements + 3 * stride];
 		const NerfCoordinate* input = network_input(i + j * n_elements);
-		Vector3f warped_pos = input->pos.p;
-		Vector3f pos = unwarp_position(warped_pos, aabb);
+		vec3 warped_pos = input->pos.p;
+		vec3 pos = unwarp_position(warped_pos, aabb);
 
-		float T = 1.f - local_rgba.w();
+		float T = 1.f - local_rgba.a;
 		float dt = unwarp_dt(input->dt);
 		float alpha = 1.f - __expf(-network_to_density(float(local_network_output[3]), density_activation) * dt);
 		if (show_accel >= 0) {
@@ -856,25 +928,25 @@ __global__ void composite_kernel_nerf(
 		}
 		float weight = alpha * T;
 
-		Array3f rgb = network_to_rgb(local_network_output, rgb_activation);
+		vec3 rgb = network_to_rgb_vec(local_network_output, rgb_activation);
 
 		if (glow_mode) { // random grid visualizations ftw!
 #if 0
 			if (0) {  // extremely startrek edition
-				float glow_y = (pos.y() - (glow_y_cutoff - 0.5f)) * 2.f;
+				float glow_y = (pos.y - (glow_y_cutoff - 0.5f)) * 2.f;
 				if (glow_y>1.f) glow_y=max(0.f,21.f-glow_y*20.f);
 				if (glow_y>0.f) {
 					float line;
-					line =max(0.f,cosf(pos.y()*2.f*3.141592653589793f * 16.f)-0.95f);
-					line+=max(0.f,cosf(pos.x()*2.f*3.141592653589793f * 16.f)-0.95f);
-					line+=max(0.f,cosf(pos.z()*2.f*3.141592653589793f * 16.f)-0.95f);
-					line+=max(0.f,cosf(pos.y()*4.f*3.141592653589793f * 16.f)-0.975f);
-					line+=max(0.f,cosf(pos.x()*4.f*3.141592653589793f * 16.f)-0.975f);
-					line+=max(0.f,cosf(pos.z()*4.f*3.141592653589793f * 16.f)-0.975f);
+					line =max(0.f,cosf(pos.y*2.f*3.141592653589793f * 16.f)-0.95f);
+					line+=max(0.f,cosf(pos.x*2.f*3.141592653589793f * 16.f)-0.95f);
+					line+=max(0.f,cosf(pos.z*2.f*3.141592653589793f * 16.f)-0.95f);
+					line+=max(0.f,cosf(pos.y*4.f*3.141592653589793f * 16.f)-0.975f);
+					line+=max(0.f,cosf(pos.x*4.f*3.141592653589793f * 16.f)-0.975f);
+					line+=max(0.f,cosf(pos.z*4.f*3.141592653589793f * 16.f)-0.975f);
 					glow_y=glow_y*glow_y*0.5f + glow_y*line*25.f;
-					rgb.y()+=glow_y;
-					rgb.z()+=glow_y*0.5f;
-					rgb.x()+=glow_y*0.25f;
+					rgb.y+=glow_y;
+					rgb.z+=glow_y*0.5f;
+					rgb.x+=glow_y*0.25f;
 				}
 			}
 #endif
@@ -891,10 +963,10 @@ __global__ void composite_kernel_nerf(
 			{
 				float dist;
 				if (radial_mode) {
-					dist = (pos - camera_matrix.col(3)).norm();
-					dist = min(dist, (4.5f - pos.y()) * 0.333f);
+					dist = distance(pos, camera_matrix[3]);
+					dist = min(dist, (4.5f - pos.y) * 0.333f);
 				} else {
-					dist = pos.y();
+					dist = pos.y;
 				}
 
 				if (grid_mode) {
@@ -906,7 +978,7 @@ __global__ void composite_kernel_nerf(
 						y *= 80.f;
 						mask = min(1.f, y);
 						//if (mask_mode) {
-						//	rgb.x()=rgb.y()=rgb.z()=mask; // mask mode
+						//	rgb.x=rgb.y=rgb.z=mask; // mask mode
 						//} else
 						{
 							if (green_cutline) {
@@ -930,28 +1002,28 @@ __global__ void composite_kernel_nerf(
 
 			if (glow > 0.f) {
 				float line;
-				line  = max(0.f, cosf(pos.y() * 2.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.x() * 2.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.z() * 2.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.y() * 4.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.x() * 4.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.z() * 4.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.y() * 8.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.x() * 8.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.z() * 8.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.y() * 16.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.x() * 16.f * 3.141592653589793f * 16.f) - 0.975f);
-				line += max(0.f, cosf(pos.z() * 16.f * 3.141592653589793f * 16.f) - 0.975f);
+				line  = max(0.f, cosf(pos.y * 2.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.x * 2.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.z * 2.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.y * 4.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.x * 4.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.z * 4.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.y * 8.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.x * 8.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.z * 8.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.y * 16.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.x * 16.f * 3.141592653589793f * 16.f) - 0.975f);
+				line += max(0.f, cosf(pos.z * 16.f * 3.141592653589793f * 16.f) - 0.975f);
 				if (grid_mode) {
 					glow = /*glow*glow*0.75f + */ glow * line * 15.f;
-					rgb.y() = glow;
-					rgb.z() = glow * 0.5f;
-					rgb.x() = glow * 0.25f;
+					rgb.y = glow;
+					rgb.z = glow * 0.5f;
+					rgb.x = glow * 0.25f;
 				} else {
 					glow = glow * glow * 0.25f + glow * line * 15.f;
-					rgb.y() += glow;
-					rgb.z() += glow * 0.5f;
-					rgb.x() += glow * 0.25f;
+					rgb.y += glow;
+					rgb.z += glow * 0.5f;
+					rgb.x += glow * 0.25f;
 				}
 			}
 		} // glow
@@ -960,39 +1032,38 @@ __global__ void composite_kernel_nerf(
 			// Network input contains the gradient of the network output w.r.t. input.
 			// So to compute density gradients, we need to apply the chain rule.
 			// The normal is then in the opposite direction of the density gradient (i.e. the direction of decreasing density)
-			Vector3f normal = -network_to_density_derivative(float(local_network_output[3]), density_activation) * warped_pos;
-			rgb = normal.normalized().array();
+			vec3 normal = -network_to_density_derivative(float(local_network_output[3]), density_activation) * warped_pos;
+			rgb = normalize(normal);
 		} else if (render_mode == ERenderMode::Positions) {
 			if (show_accel >= 0) {
 				uint32_t mip = max(show_accel, mip_from_pos(pos));
 				uint32_t res = NERF_GRIDSIZE() >> mip;
-				int ix = pos.x() * res;
-				int iy = pos.y() * res;
-				int iz = pos.z() * res;
+				int ix = pos.x * res;
+				int iy = pos.y * res;
+				int iz = pos.z * res;
 				default_rng_t rng(ix + iy * 232323 + iz * 727272);
-				rgb.x() = 1.f - mip * (1.f / (NERF_CASCADES() - 1));
-				rgb.y() = rng.next_float();
-				rgb.z() = rng.next_float();
+				rgb.x = 1.f - mip * (1.f / (NERF_CASCADES() - 1));
+				rgb.y = rng.next_float();
+				rgb.z = rng.next_float();
 			} else {
-				rgb = (pos.array() - Array3f::Constant(0.5f)) / 2.0f + Array3f::Constant(0.5f);
+				rgb = (pos - vec3(0.5f)) / 2.0f + vec3(0.5f);
 			}
 		} else if (render_mode == ERenderMode::EncodingVis) {
-			rgb = warped_pos.array();
+			rgb = warped_pos;
 		} else if (render_mode == ERenderMode::Depth) {
-			rgb = Array3f::Constant(cam_fwd.dot(pos - origin) * depth_scale);
+			rgb = vec3(dot(cam_fwd, pos - origin) * depth_scale);
 		} else if (render_mode == ERenderMode::AO) {
-			rgb = Array3f::Constant(alpha);
+			rgb = vec3(alpha);
 		}
 
-		local_rgba.head<3>() += rgb * weight;
-		local_rgba.w() += weight;
+		local_rgba += vec4(rgb * weight, weight);
 		if (weight > payload.max_weight) {
 			payload.max_weight = weight;
-			local_depth = cam_fwd.dot(pos - camera_matrix.col(3));
+			local_depth = dot(cam_fwd, pos - camera_matrix[3]);
 		}
 
-		if (local_rgba.w() > (1.0f - min_transmittance)) {
-			local_rgba /= local_rgba.w();
+		if (local_rgba.a > (1.0f - min_transmittance)) {
+			local_rgba /= local_rgba.a;
 			break;
 		}
 	}
@@ -1008,62 +1079,62 @@ __global__ void composite_kernel_nerf(
 
 static constexpr float UNIFORM_SAMPLING_FRACTION = 0.5f;
 
-inline __device__ Vector2f sample_cdf_2d(Vector2f sample, uint32_t img, const Vector2i& res, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y, float* __restrict__ pdf) {
-	if (sample.x() < UNIFORM_SAMPLING_FRACTION) {
-		sample.x() /= UNIFORM_SAMPLING_FRACTION;
+inline __device__ vec2 sample_cdf_2d(vec2 sample, uint32_t img, const ivec2& res, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y, float* __restrict__ pdf) {
+	if (sample.x < UNIFORM_SAMPLING_FRACTION) {
+		sample.x /= UNIFORM_SAMPLING_FRACTION;
 		return sample;
 	}
 
-	sample.x() = (sample.x() - UNIFORM_SAMPLING_FRACTION) / (1.0f - UNIFORM_SAMPLING_FRACTION);
+	sample.x = (sample.x - UNIFORM_SAMPLING_FRACTION) / (1.0f - UNIFORM_SAMPLING_FRACTION);
 
-	cdf_y += img * res.y();
+	cdf_y += img * res.y;
 
 	// First select row according to cdf_y
-	uint32_t y = binary_search(sample.y(), cdf_y, res.y());
+	uint32_t y = binary_search(sample.y, cdf_y, res.y);
 	float prev = y > 0 ? cdf_y[y-1] : 0.0f;
 	float pmf_y = cdf_y[y] - prev;
-	sample.y() = (sample.y() - prev) / pmf_y;
+	sample.y = (sample.y - prev) / pmf_y;
 
-	cdf_x_cond_y += img * res.y() * res.x() + y * res.x();
+	cdf_x_cond_y += img * res.y * res.x + y * res.x;
 
 	// Then, select col according to x
-	uint32_t x = binary_search(sample.x(), cdf_x_cond_y, res.x());
+	uint32_t x = binary_search(sample.x, cdf_x_cond_y, res.x);
 	prev = x > 0 ? cdf_x_cond_y[x-1] : 0.0f;
 	float pmf_x = cdf_x_cond_y[x] - prev;
-	sample.x() = (sample.x() - prev) / pmf_x;
+	sample.x = (sample.x - prev) / pmf_x;
 
 	if (pdf) {
-		*pdf = pmf_x * pmf_y * res.prod();
+		*pdf = pmf_x * pmf_y * compMul(res);
 	}
 
-	return {((float)x + sample.x()) / (float)res.x(), ((float)y + sample.y()) / (float)res.y()};
+	return {((float)x + sample.x) / (float)res.x, ((float)y + sample.y) / (float)res.y};
 }
 
-inline __device__ float pdf_2d(Vector2f sample, uint32_t img, const Vector2i& res, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y) {
-	Vector2i p = (sample.cwiseProduct(res.cast<float>())).cast<int>().cwiseMax(0).cwiseMin(res - Vector2i::Ones());
+inline __device__ float pdf_2d(vec2 sample, uint32_t img, const ivec2& res, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y) {
+	ivec2 p = clamp(ivec2(sample * vec2(res)), ivec2(0), res - ivec2(1));
 
-	cdf_y += img * res.y();
-	cdf_x_cond_y += img * res.y() * res.x() + p.y() * res.x();
+	cdf_y += img * res.y;
+	cdf_x_cond_y += img * res.y * res.x + p.y * res.x;
 
-	float pmf_y = cdf_y[p.y()];
-	if (p.y() > 0) {
-		pmf_y -= cdf_y[p.y()-1];
+	float pmf_y = cdf_y[p.y];
+	if (p.y > 0) {
+		pmf_y -= cdf_y[p.y-1];
 	}
 
-	float pmf_x = cdf_x_cond_y[p.x()];
-	if (p.x() > 0) {
-		pmf_x -= cdf_x_cond_y[p.x()-1];
+	float pmf_x = cdf_x_cond_y[p.x];
+	if (p.x > 0) {
+		pmf_x -= cdf_x_cond_y[p.x-1];
 	}
 
 	// Probability mass of picking the pixel
 	float pmf = pmf_x * pmf_y;
 
 	// To convert to probability density, divide by area of pixel
-	return UNIFORM_SAMPLING_FRACTION + pmf * res.prod() * (1.0f - UNIFORM_SAMPLING_FRACTION);
+	return UNIFORM_SAMPLING_FRACTION + pmf * compMul(res) * (1.0f - UNIFORM_SAMPLING_FRACTION);
 }
 
-inline __device__ Vector2f nerf_random_image_pos_training(default_rng_t& rng, const Vector2i& resolution, bool snap_to_pixel_centers, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y, const Vector2i& cdf_res, uint32_t img, float* __restrict__ pdf = nullptr) {
-	Vector2f uv = random_val_2d(rng);
+inline __device__ vec2 nerf_random_image_pos_training(default_rng_t& rng, const ivec2& resolution, bool snap_to_pixel_centers, const float* __restrict__ cdf_x_cond_y, const float* __restrict__ cdf_y, const ivec2& cdf_res, uint32_t img, float* __restrict__ pdf = nullptr) {
+	vec2 uv = random_val_2d(rng);
 
 	if (cdf_x_cond_y) {
 		uv = sample_cdf_2d(uv, img, cdf_res, cdf_x_cond_y, cdf_y, pdf);
@@ -1072,8 +1143,9 @@ inline __device__ Vector2f nerf_random_image_pos_training(default_rng_t& rng, co
 	}
 
 	if (snap_to_pixel_centers) {
-		uv = (uv.cwiseProduct(resolution.cast<float>()).cast<int>().cwiseMax(0).cwiseMin(resolution - Vector2i::Ones()).cast<float>() + Vector2f::Constant(0.5f)).cwiseQuotient(resolution.cast<float>());
+		uv = (vec2(clamp(ivec2(uv * vec2(resolution)), ivec2(0), resolution - ivec2(1))) + vec2(0.5f)) / vec2(resolution);
 	}
+
 	return uv;
 }
 
@@ -1100,6 +1172,24 @@ inline __device__ uint32_t image_idx(uint32_t base_idx, uint32_t n_rays, uint32_
 	return (((base_idx/* + n_rays_total*/) * n_training_images) / n_rays) % n_training_images;
 }
 
+__device__ LossAndGradient loss_and_gradient(const vec3& target, const vec3& prediction, ELossType loss_type) {
+	switch (loss_type) {
+		case ELossType::RelativeL2:  return relative_l2_loss(target, prediction); break;
+		case ELossType::L1:          return l1_loss(target, prediction); break;
+		case ELossType::Mape:        return mape_loss(target, prediction); break;
+		case ELossType::Smape:       return smape_loss(target, prediction); break;
+		// Note: we divide the huber loss by a factor of 5 such that its L2 region near zero
+		// matches with the L2 loss and error numbers become more comparable. This allows reading
+		// off dB numbers of ~converged models and treating them as approximate PSNR to compare
+		// with other NeRF methods. Self-normalizing optimizers such as Adam are agnostic to such
+		// constant factors; optimization is therefore unaffected.
+		case ELossType::Huber:       return huber_loss(target, prediction, 0.1f) / 5.0f; break;
+		case ELossType::LogL1:       return log_l1_loss(target, prediction); break;
+		default: case ELossType::L2: return l2_loss(target, prediction); break;
+	}
+}
+
+
 __global__ void generate_training_samples_nerf(
 	const uint32_t n_rays,
 	BoundingBox aabb,
@@ -1116,16 +1206,17 @@ __global__ void generate_training_samples_nerf(
 	const TrainingImageMetadata* __restrict__ metadata,
 	const TrainingXForm* training_xforms,
 	const uint8_t* __restrict__ density_grid,
+	uint32_t max_mip,
 	bool max_level_rand_training,
 	float* __restrict__ max_level_ptr,
 	bool snap_to_pixel_centers,
 	bool train_envmap,
 	float cone_angle_constant,
-	Buffer2DView<const Vector2f> distortion,
+	Buffer2DView<const vec2> distortion,
 	const float* __restrict__ cdf_x_cond_y,
 	const float* __restrict__ cdf_y,
 	const float* __restrict__ cdf_img,
-	const Vector2i cdf_res,
+	const ivec2 cdf_res,
 	const float* __restrict__ extra_dims_gpu,
 	uint32_t n_extra_dims
 ) {
@@ -1133,14 +1224,14 @@ __global__ void generate_training_samples_nerf(
 	if (i >= n_rays) return;
 
 	uint32_t img = image_idx(i, n_rays, n_rays_total, n_training_images, cdf_img);
-	Eigen::Vector2i resolution = metadata[img].resolution;
+	ivec2 resolution = metadata[img].resolution;
 
 	rng.advance(i * N_MAX_RANDOM_SAMPLES_PER_RAY());
-	Vector2f uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, cdf_res, img);
+	vec2 uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, cdf_res, img);
 
 	// Negative values indicate masked-away regions
 	size_t pix_idx = pixel_idx(uv, resolution, 0);
-	if (read_rgba(uv, resolution, metadata[img].pixels, metadata[img].image_data_type).x() < 0.0f) {
+	if (read_rgba(uv, resolution, metadata[img].pixels, metadata[img].image_data_type).x < 0.0f) {
 		return;
 	}
 
@@ -1148,12 +1239,12 @@ __global__ void generate_training_samples_nerf(
 
 	float motionblur_time = random_val(rng);
 
-	const Vector2f focal_length = metadata[img].focal_length;
-	const Vector2f principal_point = metadata[img].principal_point;
+	const vec2 focal_length = metadata[img].focal_length;
+	const vec2 principal_point = metadata[img].principal_point;
 	const float* extra_dims = extra_dims_gpu + img * n_extra_dims;
 	const Lens lens = metadata[img].lens;
 
-	const Matrix<float, 3, 4> xform = get_xform_given_rolling_shutter(training_xforms[img], metadata[img].rolling_shutter, uv, motionblur_time);
+	const mat4x3 xform = get_xform_given_rolling_shutter(training_xforms[img], metadata[img].rolling_shutter, uv, motionblur_time);
 
 	Ray ray_unnormalized;
 	const Ray* rays_in_unnormalized = metadata[img].rays;
@@ -1162,51 +1253,50 @@ __global__ void generate_training_samples_nerf(
 		ray_unnormalized = rays_in_unnormalized[pix_idx];
 
 		/* DEBUG - compare the stored rays to the computed ones
-		const Matrix<float, 3, 4> xform = get_xform_given_rolling_shutter(training_xforms[img], metadata[img].rolling_shutter, uv, 0.f);
+		const mat4x3 xform = get_xform_given_rolling_shutter(training_xforms[img], metadata[img].rolling_shutter, uv, 0.f);
 		Ray ray2;
-		ray2.o = xform.col(3);
+		ray2.o = xform[3];
 		ray2.d = f_theta_distortion(uv, principal_point, lens);
 		ray2.d = (xform.block<3, 3>(0, 0) * ray2.d).normalized();
 		if (i==1000) {
 			printf("\n%d uv %0.3f,%0.3f pixel %0.2f,%0.2f transform from [%0.5f %0.5f %0.5f] to [%0.5f %0.5f %0.5f]\n"
 				" origin    [%0.5f %0.5f %0.5f] vs [%0.5f %0.5f %0.5f]\n"
 				" direction [%0.5f %0.5f %0.5f] vs [%0.5f %0.5f %0.5f]\n"
-			, img,uv.x(), uv.y(), uv.x()*resolution.x(), uv.y()*resolution.y(),
-				training_xforms[img].start.col(3).x(),training_xforms[img].start.col(3).y(),training_xforms[img].start.col(3).z(),
-				training_xforms[img].end.col(3).x(),training_xforms[img].end.col(3).y(),training_xforms[img].end.col(3).z(),
-				ray_unnormalized.o.x(),ray_unnormalized.o.y(),ray_unnormalized.o.z(),
-				ray2.o.x(),ray2.o.y(),ray2.o.z(),
-				ray_unnormalized.d.x(),ray_unnormalized.d.y(),ray_unnormalized.d.z(),
-				ray2.d.x(),ray2.d.y(),ray2.d.z());
+			, img,uv.x, uv.y, uv.x*resolution.x, uv.y*resolution.y,
+				training_xforms[img].start[3].x,training_xforms[img].start[3].y,training_xforms[img].start[3].z,
+				training_xforms[img].end[3].x,training_xforms[img].end[3].y,training_xforms[img].end[3].z,
+				ray_unnormalized.o.x,ray_unnormalized.o.y,ray_unnormalized.o.z,
+				ray2.o.x,ray2.o.y,ray2.o.z,
+				ray_unnormalized.d.x,ray_unnormalized.d.y,ray_unnormalized.d.z,
+				ray2.d.x,ray2.d.y,ray2.d.z);
 		}
 		*/
 	} else {
-		ray_unnormalized = uv_to_ray(0, uv, resolution, focal_length, xform, principal_point, Vector3f::Zero(), 0.0f, 1.0f, 0.0f, {}, {}, lens, distortion);
+		ray_unnormalized = uv_to_ray(0, uv, resolution, focal_length, xform, principal_point, vec3(0.0f), 0.0f, 1.0f, 0.0f, {}, {}, lens, distortion);
 		if (!ray_unnormalized.is_valid()) {
-			ray_unnormalized = {xform.col(3), xform.col(2)};
+			ray_unnormalized = {xform[3], xform[2]};
 		}
 	}
 
-	Eigen::Vector3f ray_d_normalized = ray_unnormalized.d.normalized();
+	vec3 ray_d_normalized = normalize(ray_unnormalized.d);
 
-	Vector2f tminmax = aabb.ray_intersect(ray_unnormalized.o, ray_d_normalized);
-	float cone_angle = calc_cone_angle(ray_d_normalized.dot(xform.col(2)), focal_length, cone_angle_constant);
+	vec2 tminmax = aabb.ray_intersect(ray_unnormalized.o, ray_d_normalized);
+	float cone_angle = calc_cone_angle(dot(ray_d_normalized, xform[2]), focal_length, cone_angle_constant);
 
 	// The near distance prevents learning of camera-specific fudge right in front of the camera
-	tminmax.x() = fmaxf(tminmax.x(), 0.0f);
+	tminmax.x = fmaxf(tminmax.x, 0.0f);
 
-	float startt = tminmax.x();
-	startt += calc_dt(startt, cone_angle) * random_val(rng);
-	Vector3f idir = ray_d_normalized.cwiseInverse();
+	float startt = advance_n_steps(tminmax.x, cone_angle, random_val(rng));
+	vec3 idir = vec3(1.0f) / ray_d_normalized;
 
 	// first pass to compute an accurate number of steps
 	uint32_t j = 0;
 	float t = startt;
-	Vector3f pos;
+	vec3 pos;
 
 	while (aabb.contains(pos = ray_unnormalized.o + t * ray_d_normalized) && j < NERF_STEPS()) {
 		float dt = calc_dt(t, cone_angle);
-		uint32_t mip = mip_from_dt(dt, pos);
+		uint32_t mip = mip_from_dt(dt, pos, max_mip);
 		if (density_grid_occupied_at(pos, density_grid, mip)) {
 			++j;
 			t += dt;
@@ -1232,12 +1322,12 @@ __global__ void generate_training_samples_nerf(
 	numsteps_out[ray_idx*2+0] = numsteps;
 	numsteps_out[ray_idx*2+1] = base;
 
-	Vector3f warped_dir = warp_direction(ray_d_normalized);
+	vec3 warped_dir = warp_direction(ray_d_normalized);
 	t=startt;
 	j=0;
 	while (aabb.contains(pos = ray_unnormalized.o + t * ray_d_normalized) && j < numsteps) {
 		float dt = calc_dt(t, cone_angle);
-		uint32_t mip = mip_from_dt(dt, pos);
+		uint32_t mip = mip_from_dt(dt, pos, max_mip);
 		if (density_grid_occupied_at(pos, density_grid, mip)) {
 			coords_out(j)->set_with_optional_extra_dims(warp_position(pos, aabb), warped_dir, warp_dt(dt), extra_dims, coords_out.stride_in_bytes);
 			++j;
@@ -1246,6 +1336,7 @@ __global__ void generate_training_samples_nerf(
 			t = advance_to_next_voxel(t, cone_angle, pos, ray_d_normalized, idir, mip);
 		}
 	}
+
 	if (max_level_rand_training) {
 		max_level_ptr += base;
 		for (j = 0; j < numsteps; ++j) {
@@ -1254,23 +1345,6 @@ __global__ void generate_training_samples_nerf(
 	}
 }
 
-
-__device__ LossAndGradient loss_and_gradient(const Vector3f& target, const Vector3f& prediction, ELossType loss_type) {
-	switch (loss_type) {
-		case ELossType::RelativeL2:  return relative_l2_loss(target, prediction); break;
-		case ELossType::L1:          return l1_loss(target, prediction); break;
-		case ELossType::Mape:        return mape_loss(target, prediction); break;
-		case ELossType::Smape:       return smape_loss(target, prediction); break;
-		// Note: we divide the huber loss by a factor of 5 such that its L2 region near zero
-		// matches with the L2 loss and error numbers become more comparable. This allows reading
-		// off dB numbers of ~converged models and treating them as approximate PSNR to compare
-		// with other NeRF methods. Self-normalizing optimizers such as Adam are agnostic to such
-		// constant factors; optimization is therefore unaffected.
-		case ELossType::Huber:       return huber_loss(target, prediction, 0.1f) / 5.0f; break;
-		case ELossType::LogL1:       return log_l1_loss(target, prediction); break;
-		default: case ELossType::L2: return l2_loss(target, prediction); break;
-	}
-}
 
 __global__ void compute_loss_kernel_train_nerf(
 	const uint32_t n_rays,
@@ -1281,11 +1355,11 @@ __global__ void compute_loss_kernel_train_nerf(
 	const uint32_t* __restrict__ rays_counter,
 	float loss_scale,
 	int padded_output_width,
-	Buffer2DView<const Eigen::Array4f> envmap,
+	Buffer2DView<const vec4> envmap,
 	float* __restrict__ envmap_gradient,
-	const Vector2i envmap_resolution,
+	const ivec2 envmap_resolution,
 	ELossType envmap_loss_type,
-	Array3f background_color,
+	vec3 background_color,
 	EColorSpace color_space,
 	bool train_with_random_bg_color,
 	bool train_in_linear_colors,
@@ -1311,15 +1385,16 @@ __global__ void compute_loss_kernel_train_nerf(
 	const float* __restrict__ cdf_x_cond_y,
 	const float* __restrict__ cdf_y,
 	const float* __restrict__ cdf_img,
-	const Vector2i error_map_res,
-	const Vector2i error_map_cdf_res,
+	const ivec2 error_map_res,
+	const ivec2 error_map_cdf_res,
 	const float* __restrict__ sharpness_data,
-	Eigen::Vector2i sharpness_resolution,
+	ivec2 sharpness_resolution,
 	float* __restrict__ sharpness_grid,
 	float* __restrict__ density_grid,
 	const float* __restrict__ mean_density_ptr,
-	const Eigen::Array3f* __restrict__ exposure,
-	Eigen::Array3f* __restrict__ exposure_gradient,
+	uint32_t max_mip,
+	const vec3* __restrict__ exposure,
+	vec3* __restrict__ exposure_gradient,
 	float depth_supervision_lambda,
 	float near_distance
 ) {
@@ -1337,22 +1412,22 @@ __global__ void compute_loss_kernel_train_nerf(
 
 	float EPSILON = 1e-4f;
 
-	Array3f rgb_ray = Array3f::Zero();
-	Vector3f hitpoint = Vector3f::Zero();
+	vec3 rgb_ray = vec3(0.0f);
+	vec3 hitpoint = vec3(0.0f);
 
 	float depth_ray = 0.f;
 	uint32_t compacted_numsteps = 0;
-	Eigen::Vector3f ray_o = rays_in_unnormalized[i].o;
+	vec3 ray_o = rays_in_unnormalized[i].o;
 	for (; compacted_numsteps < numsteps; ++compacted_numsteps) {
 		if (T < EPSILON) {
 			break;
 		}
 
 		const tcnn::vector_t<tcnn::network_precision_t, 4> local_network_output = *(tcnn::vector_t<tcnn::network_precision_t, 4>*)network_output;
-		const Array3f rgb = network_to_rgb(local_network_output, rgb_activation);
-		const Vector3f pos = unwarp_position(coords_in.ptr->pos.p, aabb);
+		const vec3 rgb = network_to_rgb_vec(local_network_output, rgb_activation);
+		const vec3 pos = unwarp_position(coords_in.ptr->pos.p, aabb);
 		const float dt = unwarp_dt(coords_in.ptr->dt);
-		float cur_depth = (pos - ray_o).norm();
+		float cur_depth = distance(pos, ray_o);
 		float density = network_to_density(float(local_network_output[3]), density_activation);
 
 
@@ -1375,34 +1450,35 @@ __global__ void compute_loss_kernel_train_nerf(
 
 	float img_pdf = 1.0f;
 	uint32_t img = image_idx(ray_idx, n_rays, n_rays_total, n_training_images, cdf_img, &img_pdf);
-	Eigen::Vector2i resolution = metadata[img].resolution;
+	ivec2 resolution = metadata[img].resolution;
 
 	float uv_pdf = 1.0f;
-	Vector2f uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, error_map_cdf_res, img, &uv_pdf);
+	vec2 uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, error_map_cdf_res, img, &uv_pdf);
 	float max_level = max_level_rand_training ? (random_val(rng) * 2.0f) : 1.0f; // Multiply by 2 to ensure 50% of training is at max level
+	rng.advance(1); // motionblur_time
 
 	if (train_with_random_bg_color) {
 		background_color = random_val_3d(rng);
 	}
-	Array3f pre_envmap_background_color = background_color = srgb_to_linear(background_color);
+	vec3 pre_envmap_background_color = background_color = srgb_to_linear(background_color);
 
 	// Composit background behind envmap
-	Array4f envmap_value;
-	Vector3f dir;
+	vec4 envmap_value;
+	vec3 dir;
 	if (envmap) {
-		dir = rays_in_unnormalized[i].d.normalized();
+		dir = normalize(rays_in_unnormalized[i].d);
 		envmap_value = read_envmap(envmap, dir);
-		background_color = envmap_value.head<3>() + background_color * (1.0f - envmap_value.w());
+		background_color = envmap_value.rgb + background_color * (1.0f - envmap_value.a);
 	}
 
-	Array3f exposure_scale = (0.6931471805599453f * exposure[img]).exp();
-	// Array3f rgbtarget = composit_and_lerp(uv, resolution, img, training_images, background_color, exposure_scale);
-	// Array3f rgbtarget = composit(uv, resolution, img, training_images, background_color, exposure_scale);
-	Array4f texsamp = read_rgba(uv, resolution, metadata[img].pixels, metadata[img].image_data_type);
+	vec3 exposure_scale = exp(0.6931471805599453f * exposure[img]);
+	// vec3 rgbtarget = composit_and_lerp(uv, resolution, img, training_images, background_color, exposure_scale);
+	// vec3 rgbtarget = composit(uv, resolution, img, training_images, background_color, exposure_scale);
+	vec4 texsamp = read_rgba(uv, resolution, metadata[img].pixels, metadata[img].image_data_type);
 
-	Array3f rgbtarget;
+	vec3 rgbtarget;
 	if (train_in_linear_colors || color_space == EColorSpace::Linear) {
-		rgbtarget = exposure_scale * texsamp.head<3>() + (1.0f - texsamp.w()) * background_color;
+		rgbtarget = exposure_scale * texsamp.rgb + (1.0f - texsamp.a) * background_color;
 
 		if (!train_in_linear_colors) {
 			rgbtarget = linear_to_srgb(rgbtarget);
@@ -1410,8 +1486,8 @@ __global__ void compute_loss_kernel_train_nerf(
 		}
 	} else if (color_space == EColorSpace::SRGB) {
 		background_color = linear_to_srgb(background_color);
-		if (texsamp.w() > 0) {
-			rgbtarget = linear_to_srgb(exposure_scale * texsamp.head<3>() / texsamp.w()) * texsamp.w() + (1.0f - texsamp.w()) * background_color;
+		if (texsamp.a > 0) {
+			rgbtarget = linear_to_srgb(exposure_scale * texsamp.rgb / texsamp.a) * texsamp.a + (1.0f - texsamp.a) * background_color;
 		} else {
 			rgbtarget = background_color;
 		}
@@ -1442,9 +1518,9 @@ __global__ void compute_loss_kernel_train_nerf(
 	LossAndGradient lg = loss_and_gradient(rgbtarget, rgb_ray, loss_type);
 	lg.loss /= img_pdf * uv_pdf;
 
-	float target_depth = rays_in_unnormalized[i].d.norm() * ((depth_supervision_lambda > 0.0f && metadata[img].depth) ? read_depth(uv, resolution, metadata[img].depth) : -1.0f);
-	LossAndGradient lg_depth = loss_and_gradient(Array3f::Constant(target_depth), Array3f::Constant(depth_ray), depth_loss_type);
-	float depth_loss_gradient = target_depth > 0.0f ? depth_supervision_lambda * lg_depth.gradient.x() : 0;
+	float target_depth = length(rays_in_unnormalized[i].d) * ((depth_supervision_lambda > 0.0f && metadata[img].depth) ? read_depth(uv, resolution, metadata[img].depth) : -1.0f);
+	LossAndGradient lg_depth = loss_and_gradient(vec3(target_depth), vec3(depth_ray), depth_loss_type);
+	float depth_loss_gradient = target_depth > 0.0f ? depth_supervision_lambda * lg_depth.gradient.x : 0;
 
 	// Note: dividing the gradient by the PDF would cause unbiased loss estimates.
 	// Essentially: variance reduction, but otherwise the same optimization.
@@ -1452,37 +1528,37 @@ __global__ void compute_loss_kernel_train_nerf(
 	// to change the weighting of the loss function. So don't divide.
 	// lg.gradient /= img_pdf * uv_pdf;
 
-	float mean_loss = lg.loss.mean();
+	float mean_loss = compAdd(lg.loss) / 3.0f;
 	if (loss_output) {
 		loss_output[i] = mean_loss / (float)n_rays;
 	}
 
 	if (error_map) {
-		const Vector2f pos = (uv.cwiseProduct(error_map_res.cast<float>()) - Vector2f::Constant(0.5f)).cwiseMax(0.0f).cwiseMin(error_map_res.cast<float>() - Vector2f::Constant(1.0f + 1e-4f));
-		const Vector2i pos_int = pos.cast<int>();
-		const Vector2f weight = pos - pos_int.cast<float>();
+		const vec2 pos = clamp(uv * vec2(error_map_res) - vec2(0.5f), vec2(0.0f), vec2(error_map_res) - vec2(1.0f + 1e-4f));
+		const ivec2 pos_int = pos;
+		const vec2 weight = pos - vec2(pos_int);
 
-		Vector2i idx = pos_int.cwiseMin(resolution - Vector2i::Constant(2)).cwiseMax(0);
+		ivec2 idx = clamp(pos_int, ivec2(0), resolution - ivec2(2));
 
 		auto deposit_val = [&](int x, int y, float val) {
-			atomicAdd(&error_map[img * error_map_res.prod() + y * error_map_res.x() + x], val);
+			atomicAdd(&error_map[img * compMul(error_map_res) + y * error_map_res.x + x], val);
 		};
 
 		if (sharpness_data && aabb.contains(hitpoint)) {
-			Vector2i sharpness_pos = uv.cwiseProduct(sharpness_resolution.cast<float>()).cast<int>().cwiseMax(0).cwiseMin(sharpness_resolution - Vector2i::Constant(1));
-			float sharp = sharpness_data[img * sharpness_resolution.prod() + sharpness_pos.y() * sharpness_resolution.x() + sharpness_pos.x()] + 1e-6f;
+			ivec2 sharpness_pos = clamp(ivec2(uv * vec2(sharpness_resolution)), ivec2(0), sharpness_resolution - ivec2(1));
+			float sharp = sharpness_data[img * compMul(sharpness_resolution) + sharpness_pos.y * sharpness_resolution.x + sharpness_pos.x] + 1e-6f;
 
 			// The maximum value of positive floats interpreted in uint format is the same as the maximum value of the floats.
-			float grid_sharp = __uint_as_float(atomicMax((uint32_t*)&cascaded_grid_at(hitpoint, sharpness_grid, mip_from_pos(hitpoint)), __float_as_uint(sharp)));
+			float grid_sharp = __uint_as_float(atomicMax((uint32_t*)&cascaded_grid_at(hitpoint, sharpness_grid, mip_from_pos(hitpoint, max_mip)), __float_as_uint(sharp)));
 			grid_sharp = fmaxf(sharp, grid_sharp); // atomicMax returns the old value, so compute the new one locally.
 
 			mean_loss *= fmaxf(sharp / grid_sharp, 0.01f);
 		}
 
-		deposit_val(idx.x(),   idx.y(),   (1 - weight.x()) * (1 - weight.y()) * mean_loss);
-		deposit_val(idx.x()+1, idx.y(),        weight.x()  * (1 - weight.y()) * mean_loss);
-		deposit_val(idx.x(),   idx.y()+1, (1 - weight.x()) *      weight.y()  * mean_loss);
-		deposit_val(idx.x()+1, idx.y()+1,      weight.x()  *      weight.y()  * mean_loss);
+		deposit_val(idx.x,   idx.y,   (1 - weight.x) * (1 - weight.y) * mean_loss);
+		deposit_val(idx.x+1, idx.y,        weight.x  * (1 - weight.y) * mean_loss);
+		deposit_val(idx.x,   idx.y+1, (1 - weight.x) *      weight.y  * mean_loss);
+		deposit_val(idx.x+1, idx.y+1,      weight.x  *      weight.y  * mean_loss);
 	}
 
 	loss_scale /= n_rays;
@@ -1491,7 +1567,7 @@ __global__ void compute_loss_kernel_train_nerf(
 	const float output_l1_reg_density = *mean_density_ptr < NERF_MIN_OPTICAL_THICKNESS() ? 1e-4f : 0.0f;
 
 	// now do it again computing gradients
-	Array3f rgb_ray2 = { 0.f,0.f,0.f };
+	vec3 rgb_ray2 = { 0.f,0.f,0.f };
 	float depth_ray2 = 0.f;
 	T = 1.f;
 	for (uint32_t j = 0; j < compacted_numsteps; ++j) {
@@ -1503,12 +1579,12 @@ __global__ void compute_loss_kernel_train_nerf(
 		const NerfCoordinate* coord_in = coords_in(j);
 		coord_out->copy(*coord_in, coords_out.stride_in_bytes);
 
-		const Vector3f pos = unwarp_position(coord_in->pos.p, aabb);
-		float depth = (pos - ray_o).norm();
+		const vec3 pos = unwarp_position(coord_in->pos.p, aabb);
+		float depth = distance(pos, ray_o);
 
 		float dt = unwarp_dt(coord_in->dt);
 		const tcnn::vector_t<tcnn::network_precision_t, 4> local_network_output = *(tcnn::vector_t<tcnn::network_precision_t, 4>*)network_output;
-		const Array3f rgb = network_to_rgb(local_network_output, rgb_activation);
+		const vec3 rgb = network_to_rgb_vec(local_network_output, rgb_activation);
 		const float density = network_to_density(float(local_network_output[3]), density_activation);
 		const float alpha = 1.f - __expf(-density * dt);
 		const float weight = alpha * T;
@@ -1517,26 +1593,26 @@ __global__ void compute_loss_kernel_train_nerf(
 		T *= (1.f - alpha);
 
 		// we know the suffix of this ray compared to where we are up to. note the suffix depends on this step's alpha as suffix = (1-alpha)*(somecolor), so dsuffix/dalpha = -somecolor = -suffix/(1-alpha)
-		const Array3f suffix = rgb_ray - rgb_ray2;
-		const Array3f dloss_by_drgb = weight * lg.gradient;
+		const vec3 suffix = rgb_ray - rgb_ray2;
+		const vec3 dloss_by_drgb = weight * lg.gradient;
 
 		tcnn::vector_t<tcnn::network_precision_t, 4> local_dL_doutput;
 
 		// chain rule to go from dloss/drgb to dloss/dmlp_output
-		local_dL_doutput[0] = loss_scale * (dloss_by_drgb.x() * network_to_rgb_derivative(local_network_output[0], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[0])); // Penalize way too large color values
-		local_dL_doutput[1] = loss_scale * (dloss_by_drgb.y() * network_to_rgb_derivative(local_network_output[1], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[1]));
-		local_dL_doutput[2] = loss_scale * (dloss_by_drgb.z() * network_to_rgb_derivative(local_network_output[2], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[2]));
+		local_dL_doutput[0] = loss_scale * (dloss_by_drgb.x * network_to_rgb_derivative(local_network_output[0], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[0])); // Penalize way too large color values
+		local_dL_doutput[1] = loss_scale * (dloss_by_drgb.y * network_to_rgb_derivative(local_network_output[1], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[1]));
+		local_dL_doutput[2] = loss_scale * (dloss_by_drgb.z * network_to_rgb_derivative(local_network_output[2], rgb_activation) + fmaxf(0.0f, output_l2_reg * (float)local_network_output[2]));
 
 		float density_derivative = network_to_density_derivative(float(local_network_output[3]), density_activation);
 		const float depth_suffix = depth_ray - depth_ray2;
 		const float depth_supervision = depth_loss_gradient * (T * depth - depth_suffix);
 
 		float dloss_by_dmlp = density_derivative * (
-			dt * (lg.gradient.matrix().dot((T * rgb - suffix).matrix()) + depth_supervision)
+			dt * (dot(lg.gradient, T * rgb - suffix) + depth_supervision)
 		);
 
 		//static constexpr float mask_supervision_strength = 1.f; // we are already 'leaking' mask information into the nerf via the random bg colors; setting this to eg between 1 and  100 encourages density towards 0 in such regions.
-		//dloss_by_dmlp += (texsamp.w()<0.001f) ? mask_supervision_strength * weight : 0.f;
+		//dloss_by_dmlp += (texsamp.a<0.001f) ? mask_supervision_strength * weight : 0.f;
 
 		local_dL_doutput[3] =
 			loss_scale * dloss_by_dmlp +
@@ -1552,37 +1628,37 @@ __global__ void compute_loss_kernel_train_nerf(
 
 	if (exposure_gradient) {
 		// Assume symmetric loss
-		Array3f dloss_by_dgt = -lg.gradient / uv_pdf;
+		vec3 dloss_by_dgt = -lg.gradient / uv_pdf;
 
 		if (!train_in_linear_colors) {
 			dloss_by_dgt /= srgb_to_linear_derivative(rgbtarget);
 		}
 
 		// 2^exposure * log(2)
-		Array3f dloss_by_dexposure = loss_scale * dloss_by_dgt * exposure_scale * 0.6931471805599453f;
-		atomicAdd(&exposure_gradient[img].x(), dloss_by_dexposure.x());
-		atomicAdd(&exposure_gradient[img].y(), dloss_by_dexposure.y());
-		atomicAdd(&exposure_gradient[img].z(), dloss_by_dexposure.z());
+		vec3 dloss_by_dexposure = loss_scale * dloss_by_dgt * exposure_scale * 0.6931471805599453f;
+		atomicAdd(&exposure_gradient[img].x, dloss_by_dexposure.x);
+		atomicAdd(&exposure_gradient[img].y, dloss_by_dexposure.y);
+		atomicAdd(&exposure_gradient[img].z, dloss_by_dexposure.z);
 	}
 
 	if (compacted_numsteps == numsteps && envmap_gradient) {
-		Array3f loss_gradient = lg.gradient;
+		vec3 loss_gradient = lg.gradient;
 		if (envmap_loss_type != loss_type) {
 			loss_gradient = loss_and_gradient(rgbtarget, rgb_ray, envmap_loss_type).gradient;
 		}
 
-		Array3f dloss_by_dbackground = T * loss_gradient;
+		vec3 dloss_by_dbackground = T * loss_gradient;
 		if (!train_in_linear_colors) {
 			dloss_by_dbackground /= srgb_to_linear_derivative(background_color);
 		}
 
 		tcnn::vector_t<tcnn::network_precision_t, 4> dL_denvmap;
-		dL_denvmap[0] = loss_scale * dloss_by_dbackground.x();
-		dL_denvmap[1] = loss_scale * dloss_by_dbackground.y();
-		dL_denvmap[2] = loss_scale * dloss_by_dbackground.z();
+		dL_denvmap[0] = loss_scale * dloss_by_dbackground.x;
+		dL_denvmap[1] = loss_scale * dloss_by_dbackground.y;
+		dL_denvmap[2] = loss_scale * dloss_by_dbackground.z;
 
 
-		float dloss_by_denvmap_alpha = dloss_by_dbackground.matrix().dot(-pre_envmap_background_color.matrix());
+		float dloss_by_denvmap_alpha = -dot(dloss_by_dbackground, pre_envmap_background_color);
 
 		// dL_denvmap[3] = loss_scale * dloss_by_denvmap_alpha;
 		dL_denvmap[3] = (tcnn::network_precision_t)0;
@@ -1600,8 +1676,8 @@ __global__ void compute_cam_gradient_train_nerf(
 	const uint32_t* __restrict__ rays_counter,
 	const TrainingXForm* training_xforms,
 	bool snap_to_pixel_centers,
-	Vector3f* cam_pos_gradient,
-	Vector3f* cam_rot_gradient,
+	vec3* cam_pos_gradient,
+	vec3* cam_rot_gradient,
 	const uint32_t n_training_images,
 	const TrainingImageMetadata* __restrict__ metadata,
 	const uint32_t* __restrict__ ray_indices_in,
@@ -1611,12 +1687,12 @@ __global__ void compute_cam_gradient_train_nerf(
 	PitchedPtr<NerfCoordinate> coords_gradient,
 	float* __restrict__ distortion_gradient,
 	float* __restrict__ distortion_gradient_weight,
-	const Vector2i distortion_resolution,
-	Vector2f* cam_focal_length_gradient,
+	const ivec2 distortion_resolution,
+	vec2* cam_focal_length_gradient,
 	const float* __restrict__ cdf_x_cond_y,
 	const float* __restrict__ cdf_y,
 	const float* __restrict__ cdf_img,
-	const Vector2i error_map_res
+	const ivec2 error_map_res
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= *rays_counter) { return; }
@@ -1636,45 +1712,45 @@ __global__ void compute_cam_gradient_train_nerf(
 	// background color.
 	uint32_t ray_idx = ray_indices_in[i];
 	uint32_t img = image_idx(ray_idx, n_rays, n_rays_total, n_training_images, cdf_img);
-	Eigen::Vector2i resolution = metadata[img].resolution;
+	ivec2 resolution = metadata[img].resolution;
 
-	const Matrix<float, 3, 4>& xform = training_xforms[img].start;
+	const mat4x3& xform = training_xforms[img].start;
 
 	Ray ray = rays_in_unnormalized[i];
-	ray.d = ray.d.normalized();
-	Ray ray_gradient = { Vector3f::Zero(), Vector3f::Zero() };
+	ray.d = normalize(ray.d);
+	Ray ray_gradient = { vec3(0.0f), vec3(0.0f) };
 
 	// Compute ray gradient
 	for (uint32_t j = 0; j < numsteps; ++j) {
-		const Vector3f warped_pos = coords(j)->pos.p;
-		const Vector3f pos_gradient = coords_gradient(j)->pos.p.cwiseProduct(warp_position_derivative(warped_pos, aabb));
+		const vec3 warped_pos = coords(j)->pos.p;
+		const vec3 pos_gradient = coords_gradient(j)->pos.p * warp_position_derivative(warped_pos, aabb);
 		ray_gradient.o += pos_gradient;
-		const Vector3f pos = unwarp_position(warped_pos, aabb);
+		const vec3 pos = unwarp_position(warped_pos, aabb);
 
 		// Scaled by t to account for the fact that further-away objects' position
 		// changes more rapidly as the direction changes.
-		float t = (pos - ray.o).norm();
-		const Vector3f dir_gradient = coords_gradient(j)->dir.d.cwiseProduct(warp_direction_derivative(coords(j)->dir.d));
+		float t = distance(pos, ray.o);
+		const vec3 dir_gradient = coords_gradient(j)->dir.d * warp_direction_derivative(coords(j)->dir.d);
 		ray_gradient.d += pos_gradient * t + dir_gradient;
 	}
 
 	rng.advance(ray_idx * N_MAX_RANDOM_SAMPLES_PER_RAY());
 	float uv_pdf = 1.0f;
 
-	Vector2f uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, error_map_res, img, &uv_pdf);
+	vec2 uv = nerf_random_image_pos_training(rng, resolution, snap_to_pixel_centers, cdf_x_cond_y, cdf_y, error_map_res, img, &uv_pdf);
 
 	if (distortion_gradient) {
 		// Projection of the raydir gradient onto the plane normal to raydir,
 		// because that's the only degree of motion that the raydir has.
-		Vector3f orthogonal_ray_gradient = ray_gradient.d - ray.d * ray_gradient.d.dot(ray.d);
+		vec3 orthogonal_ray_gradient = ray_gradient.d - ray.d * dot(ray_gradient.d, ray.d);
 
 		// Rotate ray gradient to obtain image plane gradient.
 		// This has the effect of projecting the (already projected) ray gradient from the
 		// tangent plane of the sphere onto the image plane (which is correct!).
-		Vector3f image_plane_gradient = xform.block<3,3>(0,0).inverse() * orthogonal_ray_gradient;
+		vec3 image_plane_gradient = inverse(mat3(xform)) * orthogonal_ray_gradient;
 
 		// Splat the resulting 2D image plane gradient into the distortion params
-		deposit_image_gradient<2>(image_plane_gradient.head<2>() / uv_pdf, distortion_gradient, distortion_gradient_weight, distortion_resolution, uv);
+		deposit_image_gradient(image_plane_gradient.xy() / uv_pdf, distortion_gradient, distortion_gradient_weight, distortion_resolution, uv);
 	}
 
 	if (cam_pos_gradient) {
@@ -1690,7 +1766,7 @@ __global__ void compute_cam_gradient_train_nerf(
 		// Due to our construction of ray_gradient.d, ray_gradient.d and ray.d are
 		// orthogonal, leading to the angle_axis magnitude to equal the magnitude
 		// of ray_gradient.d.
-		Vector3f angle_axis = ray.d.cross(ray_gradient.d);
+		vec3 angle_axis = cross(ray.d, ray_gradient.d);
 
 		// Atomically reduce the ray gradient into the xform gradient
 		NGP_PRAGMA_UNROLL
@@ -1740,23 +1816,22 @@ __global__ void compute_extra_dims_gradient_train_nerf(
 
 __global__ void shade_kernel_nerf(
 	const uint32_t n_elements,
-	Array4f* __restrict__ rgba,
+	vec4* __restrict__ rgba,
 	float* __restrict__ depth,
 	NerfPayload* __restrict__ payloads,
 	ERenderMode render_mode,
 	bool train_in_linear_colors,
-	Array4f* __restrict__ frame_buffer,
+	vec4* __restrict__ frame_buffer,
 	float* __restrict__ depth_buffer
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 	NerfPayload& payload = payloads[i];
 
-	Array4f tmp = rgba[i];
-
+	vec4 tmp = rgba[i];
 	if (render_mode == ERenderMode::Normals) {
-		Array3f n = tmp.head<3>().matrix().normalized().array();
-		tmp.head<3>() = (0.5f * n + Array3f::Constant(0.5f)) * tmp.w();
+		vec3 n = normalize(tmp.xyz());
+		tmp.rgb = (0.5f * n + vec3(0.5f)) * tmp.a;
 	} else if (render_mode == ERenderMode::Cost) {
 		float col = (float)payload.n_steps / 128;
 		tmp = {col, col, col, 1.0f};
@@ -1764,20 +1839,20 @@ __global__ void shade_kernel_nerf(
 
 	if (!train_in_linear_colors && (render_mode == ERenderMode::Shade || render_mode == ERenderMode::Slice)) {
 		// Accumulate in linear colors
-		tmp.head<3>() = srgb_to_linear(tmp.head<3>());
+		tmp.rgb = srgb_to_linear(tmp.rgb);
 	}
 
-	frame_buffer[payload.idx] = tmp + frame_buffer[payload.idx] * (1.0f - tmp.w());
-	if (render_mode != ERenderMode::Slice && tmp.w() > 0.2f) {
+	frame_buffer[payload.idx] = tmp + frame_buffer[payload.idx] * (1.0f - tmp.a);
+	if (render_mode != ERenderMode::Slice && tmp.a > 0.2f) {
 		depth_buffer[payload.idx] = depth[i];
 	}
 }
 
 __global__ void compact_kernel_nerf(
 	const uint32_t n_elements,
-	Array4f* src_rgba, float* src_depth, NerfPayload* src_payloads,
-	Array4f* dst_rgba, float* dst_depth, NerfPayload* dst_payloads,
-	Array4f* dst_final_rgba, float* dst_final_depth, NerfPayload* dst_final_payloads,
+	vec4* src_rgba, float* src_depth, NerfPayload* src_payloads,
+	vec4* dst_rgba, float* dst_depth, NerfPayload* dst_payloads,
+	vec4* dst_final_rgba, float* dst_final_depth, NerfPayload* dst_final_payloads,
 	uint32_t* counter, uint32_t* finalCounter
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
@@ -1790,7 +1865,7 @@ __global__ void compact_kernel_nerf(
 		dst_payloads[idx] = src_payload;
 		dst_rgba[idx] = src_rgba[i];
 		dst_depth[idx] = src_depth[i];
-	} else if (src_rgba[i].w() > 0.001f) {
+	} else if (src_rgba[i].a > 0.001f) {
 		uint32_t idx = atomicAdd(finalCounter, 1);
 		dst_final_payloads[idx] = src_payload;
 		dst_final_rgba[idx] = src_rgba[i];
@@ -1801,44 +1876,44 @@ __global__ void compact_kernel_nerf(
 __global__ void init_rays_with_payload_kernel_nerf(
 	uint32_t sample_index,
 	NerfPayload* __restrict__ payloads,
-	Vector2i resolution,
-	Vector2f focal_length,
-	Matrix<float, 3, 4> camera_matrix0,
-	Matrix<float, 3, 4> camera_matrix1,
-	Vector4f rolling_shutter,
-	Vector2f screen_center,
-	Vector3f parallax_shift,
+	ivec2 resolution,
+	vec2 focal_length,
+	mat4x3 camera_matrix0,
+	mat4x3 camera_matrix1,
+	vec4 rolling_shutter,
+	vec2 screen_center,
+	vec3 parallax_shift,
 	bool snap_to_pixel_centers,
 	BoundingBox render_aabb,
-	Matrix3f render_aabb_to_local,
+	mat3 render_aabb_to_local,
 	float near_distance,
 	float plane_z,
 	float aperture_size,
 	Foveation foveation,
 	Lens lens,
-	Buffer2DView<const Eigen::Array4f> envmap,
-	Array4f* __restrict__ frame_buffer,
+	Buffer2DView<const vec4> envmap,
+	vec4* __restrict__ frame_buffer,
 	float* __restrict__ depth_buffer,
 	Buffer2DView<const uint8_t> hidden_area_mask,
-	Buffer2DView<const Eigen::Vector2f> distortion,
+	Buffer2DView<const vec2> distortion,
 	ERenderMode render_mode
 ) {
 	uint32_t x = threadIdx.x + blockDim.x * blockIdx.x;
 	uint32_t y = threadIdx.y + blockDim.y * blockIdx.y;
 
-	if (x >= resolution.x() || y >= resolution.y()) {
+	if (x >= resolution.x || y >= resolution.y) {
 		return;
 	}
 
-	uint32_t idx = x + resolution.x() * y;
+	uint32_t idx = x + resolution.x * y;
 
 	if (plane_z < 0) {
 		aperture_size = 0.0;
 	}
 
-	Vector2f pixel_offset = ld_random_pixel_offset(snap_to_pixel_centers ? 0 : sample_index);
-	Vector2f uv = Vector2f{(float)x + pixel_offset.x(), (float)y + pixel_offset.y()}.cwiseQuotient(resolution.cast<float>());
-	float ray_time = rolling_shutter.x() + rolling_shutter.y() * uv.x() + rolling_shutter.z() * uv.y() + rolling_shutter.w() * ld_random_val(sample_index, idx * 72239731);
+	vec2 pixel_offset = ld_random_pixel_offset(snap_to_pixel_centers ? 0 : sample_index);
+	vec2 uv = vec2{(float)x + pixel_offset.x, (float)y + pixel_offset.y} / vec2(resolution);
+	float ray_time = rolling_shutter.x + rolling_shutter.y * uv.x + rolling_shutter.z * uv.y + rolling_shutter.w * ld_random_val(sample_index, idx * 72239731);
 	Ray ray = uv_to_ray(
 		sample_index,
 		uv,
@@ -1868,7 +1943,7 @@ __global__ void init_rays_with_payload_kernel_nerf(
 	}
 
 	if (plane_z < 0) {
-		float n = ray.d.norm();
+		float n = length(ray.d);
 		payload.origin = ray.o;
 		payload.dir = (1.0f/n) * ray.d;
 		payload.t = -plane_z*n;
@@ -1879,13 +1954,13 @@ __global__ void init_rays_with_payload_kernel_nerf(
 		return;
 	}
 
-	ray.d = ray.d.normalized();
+	ray.d = normalize(ray.d);
 
 	if (envmap) {
 		frame_buffer[idx] = read_envmap(envmap, ray.d);
 	}
 
-	float t = fmaxf(render_aabb.ray_intersect(render_aabb_to_local * ray.o, render_aabb_to_local * ray.d).x(), 0.0f) + 1e-6f;
+	float t = fmaxf(render_aabb.ray_intersect(render_aabb_to_local * ray.o, render_aabb_to_local * ray.d).x, 0.0f) + 1e-6f;
 
 	if (!render_aabb.contains(render_aabb_to_local * ray(t))) {
 		payload.origin = ray.o;
@@ -1894,13 +1969,13 @@ __global__ void init_rays_with_payload_kernel_nerf(
 	}
 
 	if (render_mode == ERenderMode::Distortion) {
-		Vector2f offset = Vector2f::Zero();
+		vec2 offset = vec2(0.0f);
 		if (distortion) {
-			offset += distortion.at_lerp(Vector2f{(float)x + 0.5f, (float)y + 0.5f}.cwiseQuotient(resolution.cast<float>()));
+			offset += distortion.at_lerp(vec2{(float)x + 0.5f, (float)y + 0.5f} / vec2(resolution));
 		}
 
-		frame_buffer[idx].head<3>() = to_rgb(offset * 50.0f);
-		frame_buffer[idx].w() = 1.0f;
+		frame_buffer[idx].rgb() = to_rgb(offset * 50.0f);
+		frame_buffer[idx].a = 1.0f;
 		depth_buffer[idx] = 1.0f;
 		payload.origin = ray(MAX_DEPTH());
 		payload.alive = false;
@@ -1984,38 +2059,39 @@ void Testbed::NerfTracer::init_rays_from_camera(
 	uint32_t sample_index,
 	uint32_t padded_output_width,
 	uint32_t n_extra_dims,
-	const Vector2i& resolution,
-	const Vector2f& focal_length,
-	const Matrix<float, 3, 4>& camera_matrix0,
-	const Matrix<float, 3, 4>& camera_matrix1,
-	const Vector4f& rolling_shutter,
-	const Vector2f& screen_center,
-	const Vector3f& parallax_shift,
+	const ivec2& resolution,
+	const vec2& focal_length,
+	const mat4x3& camera_matrix0,
+	const mat4x3& camera_matrix1,
+	const vec4& rolling_shutter,
+	const vec2& screen_center,
+	const vec3& parallax_shift,
 	bool snap_to_pixel_centers,
 	const BoundingBox& render_aabb,
-	const Matrix3f& render_aabb_to_local,
+	const mat3& render_aabb_to_local,
 	float near_distance,
 	float plane_z,
 	float aperture_size,
 	const Foveation& foveation,
 	const Lens& lens,
-	const Buffer2DView<const Array4f>& envmap,
-	const Buffer2DView<const Vector2f>& distortion,
-	Eigen::Array4f* frame_buffer,
+	const Buffer2DView<const vec4>& envmap,
+	const Buffer2DView<const vec2>& distortion,
+	vec4* frame_buffer,
 	float* depth_buffer,
 	const Buffer2DView<const uint8_t>& hidden_area_mask,
 	const uint8_t* grid,
 	int show_accel,
+	uint32_t max_mip,
 	float cone_angle_constant,
 	ERenderMode render_mode,
 	cudaStream_t stream
 ) {
 	// Make sure we have enough memory reserved to render at the requested resolution
-	size_t n_pixels = (size_t)resolution.x() * resolution.y();
+	size_t n_pixels = (size_t)resolution.x * resolution.y;
 	enlarge(n_pixels, padded_output_width, n_extra_dims, stream);
 
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)resolution.x(), threads.x), div_round_up((uint32_t)resolution.y(), threads.y), 1 };
+	const dim3 blocks = { div_round_up((uint32_t)resolution.x, threads.x), div_round_up((uint32_t)resolution.y, threads.y), 1 };
 	init_rays_with_payload_kernel_nerf<<<blocks, threads, 0, stream>>>(
 		sample_index,
 		m_rays[0].payload,
@@ -2042,21 +2118,22 @@ void Testbed::NerfTracer::init_rays_from_camera(
 		render_mode
 	);
 
-	m_n_rays_initialized = resolution.x() * resolution.y();
+	m_n_rays_initialized = resolution.x * resolution.y;
 
-	CUDA_CHECK_THROW(cudaMemsetAsync(m_rays[0].rgba, 0, m_n_rays_initialized * sizeof(Array4f), stream));
+	CUDA_CHECK_THROW(cudaMemsetAsync(m_rays[0].rgba, 0, m_n_rays_initialized * sizeof(vec4), stream));
 	CUDA_CHECK_THROW(cudaMemsetAsync(m_rays[0].depth, 0, m_n_rays_initialized * sizeof(float), stream));
 
-	linear_kernel(advance_pos_nerf, 0, stream,
+	linear_kernel(advance_pos_nerf_kernel, 0, stream,
 		m_n_rays_initialized,
 		render_aabb,
 		render_aabb_to_local,
-		camera_matrix1.col(2),
+		camera_matrix1[2],
 		focal_length,
 		sample_index,
 		m_rays[0].payload,
 		grid,
 		(show_accel >= 0) ? show_accel : 0,
+		max_mip,
 		cone_angle_constant
 	);
 }
@@ -2064,19 +2141,20 @@ void Testbed::NerfTracer::init_rays_from_camera(
 uint32_t Testbed::NerfTracer::trace(
 	NerfNetwork<network_precision_t>& network,
 	const BoundingBox& render_aabb,
-	const Eigen::Matrix3f& render_aabb_to_local,
+	const mat3& render_aabb_to_local,
 	const BoundingBox& train_aabb,
-	const Vector2f& focal_length,
+	const vec2& focal_length,
 	float cone_angle_constant,
 	const uint8_t* grid,
 	ERenderMode render_mode,
-	const Eigen::Matrix<float, 3, 4> &camera_matrix,
+	const mat4x3 &camera_matrix,
 	float depth_scale,
 	int visualized_layer,
 	int visualized_dim,
 	ENerfActivation rgb_activation,
 	ENerfActivation density_activation,
 	int show_accel,
+	uint32_t max_mip,
 	float min_transmittance,
 	float glow_y_cutoff,
 	int glow_mode,
@@ -2129,12 +2207,13 @@ uint32_t Testbed::NerfTracer::trace(
 			render_aabb_to_local,
 			train_aabb,
 			focal_length,
-			camera_matrix.col(2),
+			camera_matrix[2],
 			rays_current.payload,
 			input_data,
 			n_steps_between_compaction,
 			grid,
 			(show_accel>=0) ? show_accel : 0,
+			max_mip,
 			cone_angle_constant,
 			extra_dims_gpu
 		);
@@ -2187,9 +2266,9 @@ void Testbed::NerfTracer::enlarge(size_t n_elements, uint32_t padded_output_widt
 	n_elements = next_multiple(n_elements, size_t(tcnn::batch_size_granularity));
 	size_t num_floats = sizeof(NerfCoordinate) / 4 + n_extra_dims;
 	auto scratch = allocate_workspace_and_distribute<
-		Array4f, float, NerfPayload, // m_rays[0]
-		Array4f, float, NerfPayload, // m_rays[1]
-		Array4f, float, NerfPayload, // m_rays_hit
+		vec4, float, NerfPayload, // m_rays[0]
+		vec4, float, NerfPayload, // m_rays[1]
+		vec4, float, NerfPayload, // m_rays_hit
 
 		network_precision_t,
 		float,
@@ -2220,24 +2299,36 @@ void Testbed::NerfTracer::enlarge(size_t n_elements, uint32_t padded_output_widt
 void Testbed::Nerf::Training::reset_extra_dims(default_rng_t& rng) {
 	uint32_t n_extra_dims = dataset.n_extra_dims();
 	std::vector<float> extra_dims_cpu(n_extra_dims * (dataset.n_images + 1)); // n_images + 1 since we use an extra 'slot' for the inference latent code
-	float *dst = extra_dims_cpu.data();
-	ArrayXf zero(n_extra_dims);
-	zero.setZero();
-	extra_dims_opt = std::vector<AdamOptimizer<ArrayXf>>(dataset.n_images, AdamOptimizer<ArrayXf>(1e-4f, zero));
+	float* dst = extra_dims_cpu.data();
+	extra_dims_opt = std::vector<VarAdamOptimizer>(dataset.n_images, VarAdamOptimizer(n_extra_dims, 1e-4f));
 	for (uint32_t i = 0; i < dataset.n_images; ++i) {
-		Eigen::Vector3f light_dir = warp_direction(dataset.metadata[i].light_dir.normalized());
-		extra_dims_opt[i].reset_state(zero);
-		Eigen::ArrayXf &optimzer_value = extra_dims_opt[i].variable();
+		vec3 light_dir = warp_direction(normalize(dataset.metadata[i].light_dir));
+		extra_dims_opt[i].reset_state();
+		std::vector<float>& optimzer_value = extra_dims_opt[i].variable();
 		for (uint32_t j = 0; j < n_extra_dims; ++j) {
-			if (dataset.has_light_dirs && j < 3)
+			if (dataset.has_light_dirs && j < 3) {
 				dst[j] = light_dir[j];
-			else
-				dst[j] = random_val(rng) * 2.f - 1.f;
+			} else {
+				dst[j] = random_val(rng) * 2.0f - 1.0f;
+			}
 			optimzer_value[j] = dst[j];
 		}
 		dst += n_extra_dims;
 	}
 	extra_dims_gpu.resize_and_copy_from_host(extra_dims_cpu);
+}
+
+void Testbed::Nerf::Training::update_extra_dims() {
+	uint32_t n_extra_dims = dataset.n_extra_dims();
+	std::vector<float> extra_dims_cpu(extra_dims_gpu.size());
+	for (uint32_t i = 0; i < extra_dims_opt.size(); ++i) {
+		const std::vector<float>& value = extra_dims_opt[i].variable();
+		for (uint32_t j = 0; j < n_extra_dims; ++j) {
+			extra_dims_cpu[i * n_extra_dims + j] = value[j];
+		}
+	}
+
+	CUDA_CHECK_THROW(cudaMemcpyAsync(extra_dims_gpu.data(), extra_dims_cpu.data(), extra_dims_opt.size() * n_extra_dims * sizeof(float), cudaMemcpyHostToDevice));
 }
 
 const float* Testbed::get_inference_extra_dims(cudaStream_t stream) const {
@@ -2254,8 +2345,8 @@ const float* Testbed::get_inference_extra_dims(cudaStream_t stream) const {
 	size_t size = m_nerf_network->n_extra_dims() * sizeof(float);
 	float* dims_gpu = m_nerf.training.extra_dims_gpu.data() + m_nerf.training.dataset.n_images * m_nerf.training.dataset.n_extra_dims();
 	CUDA_CHECK_THROW(cudaMemcpyAsync(dims_gpu, extra_dims_src, size, cudaMemcpyDeviceToDevice, stream));
-	Eigen::Vector3f light_dir = warp_direction(m_nerf.light_dir.normalized());
-	CUDA_CHECK_THROW(cudaMemcpyAsync(dims_gpu, &light_dir, min(size, sizeof(Eigen::Vector3f)), cudaMemcpyHostToDevice, stream));
+	vec3 light_dir = warp_direction(normalize(m_nerf.light_dir));
+	CUDA_CHECK_THROW(cudaMemcpyAsync(dims_gpu, &light_dir, min(size, sizeof(vec3)), cudaMemcpyHostToDevice, stream));
 	return dims_gpu;
 }
 
@@ -2264,11 +2355,11 @@ void Testbed::render_nerf(
 	const CudaRenderBufferView& render_buffer,
 	NerfNetwork<precision_t>& nerf_network,
 	const uint8_t* density_grid_bitfield,
-	const Vector2f& focal_length,
-	const Matrix<float, 3, 4>& camera_matrix0,
-	const Matrix<float, 3, 4>& camera_matrix1,
-	const Vector4f& rolling_shutter,
-	const Vector2f& screen_center,
+	const vec2& focal_length,
+	const mat4x3& camera_matrix0,
+	const mat4x3& camera_matrix1,
+	const vec4& rolling_shutter,
+	const vec2& screen_center,
 	const Foveation& foveation,
 	int visualized_dimension
 ) {
@@ -2284,8 +2375,10 @@ void Testbed::render_nerf(
 	NerfTracer tracer;
 
 	// Our motion vector code can't undo grid distortions -- so don't render grid distortion if DLSS is enabled
-	auto grid_distortion = m_nerf.render_with_lens_distortion && !m_dlss ? m_distortion.inference_view() : Buffer2DView<const Vector2f>{};
+	auto grid_distortion = m_nerf.render_with_lens_distortion && !m_dlss ? m_distortion.inference_view() : Buffer2DView<const vec2>{};
 	Lens lens = m_nerf.render_with_lens_distortion ? m_nerf.render_lens : Lens{};
+
+	auto resolution = render_buffer.resolution;
 
 	tracer.init_rays_from_camera(
 		render_buffer.spp,
@@ -2313,6 +2406,7 @@ void Testbed::render_nerf(
 		render_buffer.hidden_area_mask ? render_buffer.hidden_area_mask->const_view() : Buffer2DView<const uint8_t>{},
 		density_grid_bitfield,
 		m_nerf.show_accel,
+		m_nerf.max_cascade,
 		m_nerf.cone_angle_constant,
 		render_mode,
 		stream
@@ -2339,6 +2433,7 @@ void Testbed::render_nerf(
 			m_nerf.rgb_activation,
 			m_nerf.density_activation,
 			m_nerf.show_accel,
+			m_nerf.max_cascade,
 			m_nerf.render_min_transmittance,
 			m_nerf.glow_y_cutoff,
 			m_nerf.glow_mode,
@@ -2361,14 +2456,14 @@ void Testbed::render_nerf(
 
 		if (visualized_dimension == -1) {
 			nerf_network.inference(stream, positions_matrix, rgbsigma_matrix);
-			linear_kernel(compute_nerf_rgba, 0, stream, n_hit, (Array4f*)rgbsigma_matrix.data(), m_nerf.rgb_activation, m_nerf.density_activation, 0.01f, false);
+			linear_kernel(compute_nerf_rgba_kernel, 0, stream, n_hit, (vec4*)rgbsigma_matrix.data(), m_nerf.rgb_activation, m_nerf.density_activation, 0.01f, false);
 		} else {
 			nerf_network.visualize_activation(stream, m_visualized_layer, visualized_dimension, positions_matrix, rgbsigma_matrix);
 		}
 
 		linear_kernel(shade_kernel_nerf, 0, stream,
 			n_hit,
-			(Array4f*)rgbsigma_matrix.data(),
+			(vec4*)rgbsigma_matrix.data(),
 			nullptr,
 			rays_hit.payload,
 			m_render_mode,
@@ -2410,8 +2505,8 @@ void Testbed::Nerf::Training::set_camera_intrinsics(int frame_idx, float fx, flo
 	if (fx <= 0.f) fx = fy;
 	if (fy <= 0.f) fy = fx;
 	auto& m = dataset.metadata[frame_idx];
-	if (cx < 0.f) cx = -cx; else cx = cx / m.resolution.x();
-	if (cy < 0.f) cy = -cy; else cy = cy / m.resolution.y();
+	if (cx < 0.f) cx = -cx; else cx = cx / m.resolution.x;
+	if (cy < 0.f) cy = -cy; else cy = cy / m.resolution.y;
 	m.lens = { ELensMode::Perspective };
 	if (k1 || k2 || k3 || k4 || p1 || p2) {
 		if (is_fisheye) {
@@ -2426,7 +2521,7 @@ void Testbed::Nerf::Training::set_camera_intrinsics(int frame_idx, float fx, flo
 	dataset.update_metadata(frame_idx, frame_idx + 1);
 }
 
-void Testbed::Nerf::Training::set_camera_extrinsics_rolling_shutter(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world_start, Eigen::Matrix<float, 3, 4> camera_to_world_end, const Vector4f& rolling_shutter, bool convert_to_ngp) {
+void Testbed::Nerf::Training::set_camera_extrinsics_rolling_shutter(int frame_idx, mat4x3 camera_to_world_start, mat4x3 camera_to_world_end, const vec4& rolling_shutter, bool convert_to_ngp) {
 	if (frame_idx < 0 || frame_idx >= dataset.n_images) {
 		return;
 	}
@@ -2447,8 +2542,8 @@ void Testbed::Nerf::Training::set_camera_extrinsics_rolling_shutter(int frame_id
 	update_transforms(frame_idx, frame_idx + 1);
 }
 
-void Testbed::Nerf::Training::set_camera_extrinsics(int frame_idx, Eigen::Matrix<float, 3, 4> camera_to_world, bool convert_to_ngp) {
-	set_camera_extrinsics_rolling_shutter(frame_idx, camera_to_world, camera_to_world, Vector4f::Zero(), convert_to_ngp);
+void Testbed::Nerf::Training::set_camera_extrinsics(int frame_idx, mat4x3 camera_to_world, bool convert_to_ngp) {
+	set_camera_extrinsics_rolling_shutter(frame_idx, camera_to_world, camera_to_world, vec4(0.0f), convert_to_ngp);
 }
 
 void Testbed::Nerf::Training::reset_camera_extrinsics() {
@@ -2471,29 +2566,29 @@ void Testbed::Nerf::Training::export_camera_extrinsics(const fs::path& path, boo
 	for(int i = 0; i < n_images_for_training; ++i) {
 		nlohmann::json frame{{"id", i}};
 
-		const Eigen::Matrix<float, 3, 4> p_nerf = get_camera_extrinsics(i);
+		const mat4x3 p_nerf = get_camera_extrinsics(i);
 		if (export_extrinsics_in_quat_format) {
 			// Assume 30 fps
 			frame["time"] =  i*0.033f;
 			// Convert the pose from NeRF to Quaternion format.
-			const Eigen::Matrix<float, 3, 3> conv_coords_l{
-				{ 0.f,  1.f,  0.f},
-				{ 0.f,  0.f, -1.f},
-				{-1.f,  0.f,  0.f}
+			const mat3 conv_coords_l{
+				 0.f,   0.f,  -1.f,
+				 1.f,   0.f,   0.f,
+				 0.f,  -1.f,   0.f,
 			};
-			const Eigen::Matrix<float, 4, 4> conv_coords_r{
-				{ 1.f,  0.f,  0.f,  0.f},
-				{ 0.f, -1.f,  0.f,  0.f},
-				{ 0.f,  0.f, -1.f,  0.f},
-				{ 0.f,  0.f,  0.f,  1.f}
+			const mat4 conv_coords_r{
+				1.f,  0.f,  0.f,  0.f,
+				0.f, -1.f,  0.f,  0.f,
+				0.f,  0.f, -1.f,  0.f,
+				0.f,  0.f,  0.f,  1.f,
 			};
-			const Eigen::Matrix<float, 3, 4> p_quat = conv_coords_l * p_nerf * conv_coords_r;
+			const mat4x3 p_quat = conv_coords_l * p_nerf * conv_coords_r;
 
-			const Eigen::Quaternionf rot_q {p_quat.block<3, 3>(0, 0)};
-			frame["q"] = {rot_q.w(), rot_q.x(), rot_q.y(), rot_q.z()};
-			frame["t"] = {p_quat(0, 3), p_quat(1, 3), p_quat(2, 3)};
+			const quat rot_q = mat3(p_quat);
+			frame["q"] = rot_q;
+			frame["t"] = p_quat[3];
 		} else {
-			frame["transform_matrix"] = {p_nerf.row(0), p_nerf.row(1), p_nerf.row(2)};
+			frame["transform_matrix"] = p_nerf;
 		}
 
 		trajectory.emplace_back(frame);
@@ -2503,9 +2598,9 @@ void Testbed::Nerf::Training::export_camera_extrinsics(const fs::path& path, boo
 	file << std::setw(2) << trajectory << std::endl;
 }
 
-Eigen::Matrix<float, 3, 4> Testbed::Nerf::Training::get_camera_extrinsics(int frame_idx) {
+mat4x3 Testbed::Nerf::Training::get_camera_extrinsics(int frame_idx) {
 	if (frame_idx < 0 || frame_idx >= dataset.n_images) {
-		return Eigen::Matrix<float, 3, 4>::Identity();
+		return mat4x3(1.0f);
 	}
 	return dataset.ngp_matrix_to_nerf(transforms[frame_idx].start);
 }
@@ -2530,26 +2625,25 @@ void Testbed::Nerf::Training::update_transforms(int first, int last) {
 
 	for (uint32_t i = 0; i < n; ++i) {
 		auto xform = dataset.xforms[i + first];
-		if (std::abs(xform.start.block<3, 3>(0, 0).determinant() - 1.0f) > 0.01f || std::abs(xform.end.block<3, 3>(0, 0).determinant() - 1.0f) > 0.01f) {
+		float det_start = determinant(mat3(xform.start));
+		float det_end = determinant(mat3(xform.end));
+		if (distance(det_start, 1.0f) > 0.01f || distance(det_end, 1.0f) > 0.01f) {
 			tlog::warning() << "Rotation of camera matrix in frame " << i + first << " has a scaling component (determinant!=1).";
 			tlog::warning() << "Normalizing the matrix. This hints at an issue in your data generation pipeline and should be fixed.";
 
-			dataset.xforms[i + first].start.block<3, 3>(0, 0) /= std::cbrt(xform.start.block<3, 3>(0, 0).determinant());
-			dataset.xforms[i + first].end.block<3, 3>(0, 0) /= std::cbrt(xform.end.block<3, 3>(0, 0).determinant());
-			xform = dataset.xforms[i + first];
+			xform.start[0] /= std::cbrt(det_start); xform.start[1] /= std::cbrt(det_start); xform.start[2] /= std::cbrt(det_start);
+			xform.end[0]   /= std::cbrt(det_end);   xform.end[1]   /= std::cbrt(det_end);   xform.end[2]   /= std::cbrt(det_end);
+			dataset.xforms[i + first] = xform;
 		}
 
-		Vector3f rot = cam_rot_offset[i + first].variable();
-		float angle = rot.norm();
-		rot /= angle;
+		mat3 rot = rotmat(cam_rot_offset[i + first].variable());
+		auto rot_start = rot * mat3(xform.start);
+		auto rot_end = rot * mat3(xform.end);
+		xform.start = mat4x3(rot_start[0], rot_start[1], rot_start[2], xform.start[3]);
+		xform.end = mat4x3(rot_end[0], rot_end[1], rot_end[2], xform.end[3]);
 
-		if (angle > 0) {
-			xform.start.block<3, 3>(0, 0) = AngleAxisf(angle, rot) * xform.start.block<3, 3>(0, 0);
-			xform.end.block<3, 3>(0, 0) = AngleAxisf(angle, rot) * xform.end.block<3, 3>(0, 0);
-		}
-
-		xform.start.col(3) += cam_pos_offset[i + first].variable();
-		xform.end.col(3) += cam_pos_offset[i + first].variable();
+		xform.start[3] += cam_pos_offset[i + first].variable();
+		xform.end[3] += cam_pos_offset[i + first].variable();
 		transforms[i + first] = xform;
 	}
 
@@ -2573,56 +2667,51 @@ void Testbed::load_nerf_post() { // moved the second half of load_nerf here
 
 	m_nerf.training.dataset.update_metadata();
 
-	m_nerf.training.cam_pos_gradient.resize(m_nerf.training.dataset.n_images, Vector3f::Zero());
+	m_nerf.training.cam_pos_gradient.resize(m_nerf.training.dataset.n_images, vec3(0.0f));
 	m_nerf.training.cam_pos_gradient_gpu.resize_and_copy_from_host(m_nerf.training.cam_pos_gradient);
 
-	m_nerf.training.cam_exposure.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Array3f>(1e-3f));
-	m_nerf.training.cam_pos_offset.resize(m_nerf.training.dataset.n_images, AdamOptimizer<Vector3f>(1e-4f));
+	m_nerf.training.cam_exposure.resize(m_nerf.training.dataset.n_images, AdamOptimizer<vec3>(1e-3f));
+	m_nerf.training.cam_pos_offset.resize(m_nerf.training.dataset.n_images, AdamOptimizer<vec3>(1e-4f));
 	m_nerf.training.cam_rot_offset.resize(m_nerf.training.dataset.n_images, RotationAdamOptimizer(1e-4f));
-	m_nerf.training.cam_focal_length_offset = AdamOptimizer<Vector2f>(1e-5f);
+	m_nerf.training.cam_focal_length_offset = AdamOptimizer<vec2>(1e-5f);
 
-	m_nerf.training.cam_rot_gradient.resize(m_nerf.training.dataset.n_images, Vector3f::Zero());
+	m_nerf.training.cam_rot_gradient.resize(m_nerf.training.dataset.n_images, vec3(0.0f));
 	m_nerf.training.cam_rot_gradient_gpu.resize_and_copy_from_host(m_nerf.training.cam_rot_gradient);
 
-	m_nerf.training.cam_exposure_gradient.resize(m_nerf.training.dataset.n_images, Array3f::Zero());
+	m_nerf.training.cam_exposure_gradient.resize(m_nerf.training.dataset.n_images, vec3(0.0f));
 	m_nerf.training.cam_exposure_gpu.resize_and_copy_from_host(m_nerf.training.cam_exposure_gradient);
 	m_nerf.training.cam_exposure_gradient_gpu.resize_and_copy_from_host(m_nerf.training.cam_exposure_gradient);
 
-	m_nerf.training.cam_focal_length_gradient = Vector2f::Zero();
+	m_nerf.training.cam_focal_length_gradient = vec2(0.0f);
 	m_nerf.training.cam_focal_length_gradient_gpu.resize_and_copy_from_host(&m_nerf.training.cam_focal_length_gradient, 1);
 
 	m_nerf.training.reset_extra_dims(m_rng);
-	m_nerf.training.optimize_extra_dims = m_nerf.training.dataset.n_extra_learnable_dims;
+	m_nerf.training.optimize_extra_dims = m_nerf.training.dataset.n_extra_learnable_dims > 0;
 
 	if (m_nerf.training.dataset.has_rays) {
 		m_nerf.training.near_distance = 0.0f;
-		// m_nerf.training.optimize_exposure = true;
 	}
-
-	// Uncomment the following line to see how the network learns distortion from scratch rather than
-	// starting from the distortion that's described by the training data.
-	// m_nerf.training.dataset.camera = {};
 
 	// Perturbation of the training cameras -- for debugging the online extrinsics learning code
-	float perturb_amount = 0.0f;
-	if (perturb_amount > 0.f) {
-		for (uint32_t i = 0; i < m_nerf.training.dataset.n_images; ++i) {
-			Vector3f rot = random_val_3d(m_rng) * perturb_amount;
-			float angle = rot.norm();
-			rot /= angle;
-			auto trans = random_val_3d(m_rng);
-			m_nerf.training.dataset.xforms[i].start.block<3,3>(0,0) = AngleAxisf(angle, rot).matrix() * m_nerf.training.dataset.xforms[i].start.block<3,3>(0,0);
-			m_nerf.training.dataset.xforms[i].start.col(3) += trans * perturb_amount;
-			m_nerf.training.dataset.xforms[i].end.block<3,3>(0,0) = AngleAxisf(angle, rot).matrix() * m_nerf.training.dataset.xforms[i].end.block<3,3>(0,0);
-			m_nerf.training.dataset.xforms[i].end.col(3) += trans * perturb_amount;
-		}
-	}
+	// float perturb_amount = 0.0f;
+	// if (perturb_amount > 0.f) {
+	// 	for (uint32_t i = 0; i < m_nerf.training.dataset.n_images; ++i) {
+	// 		vec3 rot = random_val_3d(m_rng) * perturb_amount;
+	// 		float angle = rot.norm();
+	// 		rot /= angle;
+	// 		auto trans = random_val_3d(m_rng);
+	// 		m_nerf.training.dataset.xforms[i].start.block<3,3>(0,0) = AngleAxisf(angle, rot).matrix() * m_nerf.training.dataset.xforms[i].start.block<3,3>(0,0);
+	// 		m_nerf.training.dataset.xforms[i].start[3] += trans * perturb_amount;
+	// 		m_nerf.training.dataset.xforms[i].end.block<3,3>(0,0) = AngleAxisf(angle, rot).matrix() * m_nerf.training.dataset.xforms[i].end.block<3,3>(0,0);
+	// 		m_nerf.training.dataset.xforms[i].end[3] += trans * perturb_amount;
+	// 	}
+	// }
 
 	m_nerf.training.update_transforms();
 
 	if (!m_nerf.training.dataset.metadata.empty()) {
 		m_nerf.render_lens = m_nerf.training.dataset.metadata[0].lens;
-		m_screen_center = Eigen::Vector2f::Constant(1.f) - m_nerf.training.dataset.metadata[0].principal_point;
+		m_screen_center = vec2(1.f) - m_nerf.training.dataset.metadata[0].principal_point;
 	}
 
 	if (!is_pot(m_nerf.training.dataset.aabb_scale)) {
@@ -2638,7 +2727,7 @@ void Testbed::load_nerf_post() { // moved the second half of load_nerf here
 		)};
 	}
 
-	m_aabb = BoundingBox{Vector3f::Constant(0.5f), Vector3f::Constant(0.5f)};
+	m_aabb = BoundingBox{vec3(0.5f), vec3(0.5f)};
 	m_aabb.inflate(0.5f * std::min(1 << (NERF_CASCADES()-1), m_nerf.training.dataset.aabb_scale));
 	m_raw_aabb = m_aabb;
 	m_render_aabb = m_aabb;
@@ -2800,7 +2889,7 @@ void Testbed::update_density_grid_mean_and_bitfield(cudaStream_t stream) {
 	set_all_devices_dirty();
 }
 
-__global__ void mark_density_grid_in_sphere_empty_kernel(const uint32_t n_elements, float* density_grid, Vector3f pos, float radius) {
+__global__ void mark_density_grid_in_sphere_empty_kernel(const uint32_t n_elements, float* density_grid, vec3 pos, float radius) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 	if (i >= n_elements) return;
 
@@ -2813,15 +2902,15 @@ __global__ void mark_density_grid_in_sphere_empty_kernel(const uint32_t n_elemen
 	uint32_t z = tcnn::morton3D_invert(pos_idx>>2);
 
 	float cell_radius = scalbnf(SQRT3(), level) / NERF_GRIDSIZE();
-	Vector3f cell_pos = ((Vector3f{(float)x+0.5f, (float)y+0.5f, (float)z+0.5f}) / NERF_GRIDSIZE() - Vector3f::Constant(0.5f)) * scalbnf(1.0f, level) + Vector3f::Constant(0.5f);
+	vec3 cell_pos = ((vec3{(float)x+0.5f, (float)y+0.5f, (float)z+0.5f}) / (float)NERF_GRIDSIZE() - vec3(0.5f)) * scalbnf(1.0f, level) + vec3(0.5f);
 
 	// Disable if the cell touches the sphere (conservatively, by bounding the cell with a sphere)
-	if ((pos - cell_pos).norm() < radius + cell_radius) {
+	if (distance(pos, cell_pos) < radius + cell_radius) {
 		density_grid[i] = -1.0f;
 	}
 }
 
-void Testbed::mark_density_grid_in_sphere_empty(const Vector3f& pos, float radius, cudaStream_t stream) {
+void Testbed::mark_density_grid_in_sphere_empty(const vec3& pos, float radius, cudaStream_t stream) {
 	const uint32_t n_elements = NERF_GRID_N_CELLS() * (m_nerf.max_cascade + 1);
 	if (m_nerf.density_grid.size() != n_elements) {
 		return;
@@ -2906,9 +2995,9 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 
 	if (m_nerf.training.n_steps_since_error_map_update == 0 && !m_nerf.training.dataset.metadata.empty()) {
 		uint32_t n_samples_per_image = (m_nerf.training.n_steps_between_error_map_updates * m_nerf.training.counters_rgb.rays_per_batch) / m_nerf.training.dataset.n_images;
-		Eigen::Vector2i res = m_nerf.training.dataset.metadata[0].resolution;
-		m_nerf.training.error_map.resolution = Vector2i::Constant((int)(std::sqrt(std::sqrt((float)n_samples_per_image)) * 3.5f)).cwiseMin(res);
-		m_nerf.training.error_map.data.resize(m_nerf.training.error_map.resolution.prod() * m_nerf.training.dataset.n_images);
+		ivec2 res = m_nerf.training.dataset.metadata[0].resolution;
+		m_nerf.training.error_map.resolution = min(ivec2((int)(std::sqrt(std::sqrt((float)n_samples_per_image)) * 3.5f)), res);
+		m_nerf.training.error_map.data.resize(compMul(m_nerf.training.error_map.resolution) * m_nerf.training.dataset.n_images);
 		CUDA_CHECK_THROW(cudaMemsetAsync(m_nerf.training.error_map.data.data(), 0, m_nerf.training.error_map.data.get_bytes(), stream));
 	}
 
@@ -2948,8 +3037,8 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 	bool accumulate_error = true;
 	if (accumulate_error && m_nerf.training.n_steps_since_error_map_update >= m_nerf.training.n_steps_between_error_map_updates) {
 		m_nerf.training.error_map.cdf_resolution = m_nerf.training.error_map.resolution;
-		m_nerf.training.error_map.cdf_x_cond_y.resize(m_nerf.training.error_map.cdf_resolution.prod() * m_nerf.training.dataset.n_images);
-		m_nerf.training.error_map.cdf_y.resize(m_nerf.training.error_map.cdf_resolution.y() * m_nerf.training.dataset.n_images);
+		m_nerf.training.error_map.cdf_x_cond_y.resize(compMul(m_nerf.training.error_map.cdf_resolution) * m_nerf.training.dataset.n_images);
+		m_nerf.training.error_map.cdf_y.resize(m_nerf.training.error_map.cdf_resolution.y * m_nerf.training.dataset.n_images);
 		m_nerf.training.error_map.cdf_img.resize(m_nerf.training.dataset.n_images);
 
 		CUDA_CHECK_THROW(cudaMemsetAsync(m_nerf.training.error_map.cdf_x_cond_y.data(), 0, m_nerf.training.error_map.cdf_x_cond_y.get_bytes(), stream));
@@ -2957,16 +3046,16 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 		CUDA_CHECK_THROW(cudaMemsetAsync(m_nerf.training.error_map.cdf_img.data(), 0, m_nerf.training.error_map.cdf_img.get_bytes(), stream));
 
 		const dim3 threads = { 16, 8, 1 };
-		const dim3 blocks = { div_round_up((uint32_t)m_nerf.training.error_map.cdf_resolution.y(), threads.x), div_round_up((uint32_t)m_nerf.training.dataset.n_images, threads.y), 1 };
+		const dim3 blocks = { div_round_up((uint32_t)m_nerf.training.error_map.cdf_resolution.y, threads.x), div_round_up((uint32_t)m_nerf.training.dataset.n_images, threads.y), 1 };
 		construct_cdf_2d<<<blocks, threads, 0, stream>>>(
-			m_nerf.training.dataset.n_images, m_nerf.training.error_map.cdf_resolution.y(), m_nerf.training.error_map.cdf_resolution.x(),
+			m_nerf.training.dataset.n_images, m_nerf.training.error_map.cdf_resolution.y, m_nerf.training.error_map.cdf_resolution.x,
 			m_nerf.training.error_map.data.data(),
 			m_nerf.training.error_map.cdf_x_cond_y.data(),
 			m_nerf.training.error_map.cdf_y.data()
 		);
 		linear_kernel(construct_cdf_1d, 0, stream,
 			m_nerf.training.dataset.n_images,
-			m_nerf.training.error_map.cdf_resolution.y(),
+			m_nerf.training.error_map.cdf_resolution.y,
 			m_nerf.training.error_map.cdf_y.data(),
 			m_nerf.training.error_map.cdf_img.data()
 		);
@@ -2999,15 +3088,14 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 	// Get extrinsics gradients
 	m_nerf.training.n_steps_since_cam_update += 1;
 
-
 	if (train_extra_dims) {
 		std::vector<float> extra_dims_gradient(m_nerf.training.extra_dims_gradient_gpu.size());
-		std::vector<float> &extra_dims_new_values = extra_dims_gradient; // just create an alias to make the code clearer.
 		m_nerf.training.extra_dims_gradient_gpu.copy_to_host(extra_dims_gradient);
+
 		// Optimization step
 		for (uint32_t i = 0; i < m_nerf.training.n_images_for_training; ++i) {
-			ArrayXf gradient(n_extra_dims);
-			for (uint32_t j = 0; j<n_extra_dims; ++j) {
+			std::vector<float> gradient(n_extra_dims);
+			for (uint32_t j = 0; j < n_extra_dims; ++j) {
 				gradient[j] = extra_dims_gradient[i * n_extra_dims + j] / LOSS_SCALE;
 			}
 
@@ -3016,14 +3104,9 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 
 			m_nerf.training.extra_dims_opt[i].set_learning_rate(m_optimizer->learning_rate());
 			m_nerf.training.extra_dims_opt[i].step(gradient);
-
-			const ArrayXf &value = m_nerf.training.extra_dims_opt[i].variable();
-			for (uint32_t j = 0; j < n_extra_dims; ++j) {
-				extra_dims_new_values[i * n_extra_dims + j] = value[j];
-			}
 		}
 
-		CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.extra_dims_gpu.data(), extra_dims_new_values.data(), m_nerf.training.n_images_for_training * n_extra_dims * sizeof(float) , cudaMemcpyHostToDevice, stream));
+		m_nerf.training.update_extra_dims();
 	}
 
 	bool train_camera = m_nerf.training.optimize_extrinsics || m_nerf.training.optimize_distortion || m_nerf.training.optimize_focal_length || m_nerf.training.optimize_exposure;
@@ -3038,8 +3121,8 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 
 			// Optimization step
 			for (uint32_t i = 0; i < m_nerf.training.n_images_for_training; ++i) {
-				Vector3f pos_gradient = m_nerf.training.cam_pos_gradient[i] * per_camera_loss_scale;
-				Vector3f rot_gradient = m_nerf.training.cam_rot_gradient[i] * per_camera_loss_scale;
+				vec3 pos_gradient = m_nerf.training.cam_pos_gradient[i] * per_camera_loss_scale;
+				vec3 rot_gradient = m_nerf.training.cam_rot_gradient[i] * per_camera_loss_scale;
 
 				float l2_reg = m_nerf.training.extrinsic_l2_reg;
 				pos_gradient += m_nerf.training.cam_pos_offset[i].variable() * l2_reg;
@@ -3065,9 +3148,9 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 		}
 
 		if (m_nerf.training.optimize_focal_length) {
-			CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.cam_focal_length_gradient.data(),m_nerf.training.cam_focal_length_gradient_gpu.data(),m_nerf.training.cam_focal_length_gradient_gpu.get_bytes(),cudaMemcpyDeviceToHost, stream));
+			CUDA_CHECK_THROW(cudaMemcpyAsync(&m_nerf.training.cam_focal_length_gradient, m_nerf.training.cam_focal_length_gradient_gpu.data(), m_nerf.training.cam_focal_length_gradient_gpu.get_bytes(), cudaMemcpyDeviceToHost, stream));
 			CUDA_CHECK_THROW(cudaStreamSynchronize(stream));
-			Vector2f focal_length_gradient = m_nerf.training.cam_focal_length_gradient * per_camera_loss_scale;
+			vec2 focal_length_gradient = m_nerf.training.cam_focal_length_gradient * per_camera_loss_scale;
 			float l2_reg = m_nerf.training.intrinsic_l2_reg;
 			focal_length_gradient += m_nerf.training.cam_focal_length_offset.variable() * l2_reg;
 			m_nerf.training.cam_focal_length_offset.set_learning_rate(std::max(1e-3f * std::pow(0.33f, (float)(m_nerf.training.cam_focal_length_offset.step() / 128)),m_optimizer->learning_rate() / 1000.0f));
@@ -3078,11 +3161,11 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 		if (m_nerf.training.optimize_exposure) {
 			CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.cam_exposure_gradient.data(), m_nerf.training.cam_exposure_gradient_gpu.data(), m_nerf.training.cam_exposure_gradient_gpu.get_bytes(), cudaMemcpyDeviceToHost, stream));
 
-			Array3f mean_exposure = Array3f::Constant(0.0f);
+			vec3 mean_exposure = vec3(0.0f);
 
 			// Optimization step
 			for (uint32_t i = 0; i < m_nerf.training.n_images_for_training; ++i) {
-				Array3f gradient = m_nerf.training.cam_exposure_gradient[i] * per_camera_loss_scale;
+				vec3 gradient = m_nerf.training.cam_exposure_gradient[i] * per_camera_loss_scale;
 
 				float l2_reg = m_nerf.training.exposure_l2_reg;
 				gradient += m_nerf.training.cam_exposure[i].variable() * l2_reg;
@@ -3096,12 +3179,12 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 			mean_exposure /= m_nerf.training.n_images_for_training;
 
 			// Renormalize
-			std::vector<Array3f> cam_exposures(m_nerf.training.n_images_for_training);
+			std::vector<vec3> cam_exposures(m_nerf.training.n_images_for_training);
 			for (uint32_t i = 0; i < m_nerf.training.n_images_for_training; ++i) {
 				cam_exposures[i] = m_nerf.training.cam_exposure[i].variable() -= mean_exposure;
 			}
 
-			CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.cam_exposure_gpu.data(), cam_exposures.data(), m_nerf.training.n_images_for_training * sizeof(Array3f), cudaMemcpyHostToDevice, stream));
+			CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.cam_exposure_gpu.data(), cam_exposures.data(), m_nerf.training.n_images_for_training * sizeof(vec3), cudaMemcpyHostToDevice, stream));
 		}
 
 		m_nerf.training.n_steps_since_cam_update = 0;
@@ -3162,9 +3245,6 @@ void Testbed::train_nerf_step(uint32_t target_batch_size, Testbed::NerfCounters&
 		max_inference = next_multiple(std::min(counters.measured_batch_size_before_compaction, max_samples), tcnn::batch_size_granularity);
 	}
 
-	GPUMatrix<float> coords_matrix((float*)coords, floats_per_coord, max_inference);
-	GPUMatrix<network_precision_t> rgbsigma_matrix(mlp_out, padded_output_width, max_inference);
-
 	GPUMatrix<float> compacted_coords_matrix((float*)coords_compacted, floats_per_coord, target_batch_size);
 	GPUMatrix<network_precision_t> compacted_rgbsigma_matrix(mlp_out, padded_output_width, target_batch_size);
 
@@ -3190,98 +3270,103 @@ void Testbed::train_nerf_step(uint32_t target_batch_size, Testbed::NerfCounters&
 
 	CUDA_CHECK_THROW(cudaMemsetAsync(ray_counter, 0, sizeof(uint32_t), stream));
 
-	linear_kernel(generate_training_samples_nerf, 0, stream,
-		counters.rays_per_batch,
-		m_aabb,
-		max_inference,
-		n_rays_total,
-		m_rng,
-		ray_counter,
-		counters.numsteps_counter.data(),
-		ray_indices,
-		rays_unnormalized,
-		numsteps,
-		PitchedPtr<NerfCoordinate>((NerfCoordinate*)coords, 1, 0, extra_stride),
-		m_nerf.training.n_images_for_training,
-		m_nerf.training.dataset.metadata_gpu.data(),
-		m_nerf.training.transforms_gpu.data(),
-		m_nerf.density_grid_bitfield.data(),
-		m_max_level_rand_training,
-		max_level,
-		m_nerf.training.snap_to_pixel_centers,
-		m_nerf.training.train_envmap,
-		m_nerf.cone_angle_constant,
-		m_distortion.view(),
-		sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_x_cond_y.data() : nullptr,
-		sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_y.data() : nullptr,
-		sample_image_proportional_to_error ? m_nerf.training.error_map.cdf_img.data() : nullptr,
-		m_nerf.training.error_map.cdf_resolution,
-		m_nerf.training.extra_dims_gpu.data(),
-		m_nerf_network->n_extra_dims()
-	);
-
 	auto hg_enc = dynamic_cast<GridEncoding<network_precision_t>*>(m_encoding.get());
-	if (hg_enc) {
-		hg_enc->set_max_level_gpu(m_max_level_rand_training ? max_level : nullptr);
-	}
 
-	m_network->inference_mixed_precision(stream, coords_matrix, rgbsigma_matrix, false);
+		linear_kernel(generate_training_samples_nerf, 0, stream,
+			counters.rays_per_batch,
+			m_aabb,
+			max_inference,
+			n_rays_total,
+			m_rng,
+			ray_counter,
+			counters.numsteps_counter.data(),
+			ray_indices,
+			rays_unnormalized,
+			numsteps,
+			PitchedPtr<NerfCoordinate>((NerfCoordinate*)coords, 1, 0, extra_stride),
+			m_nerf.training.n_images_for_training,
+			m_nerf.training.dataset.metadata_gpu.data(),
+			m_nerf.training.transforms_gpu.data(),
+			m_nerf.density_grid_bitfield.data(),
+			m_nerf.max_cascade,
+			m_max_level_rand_training,
+			max_level,
+			m_nerf.training.snap_to_pixel_centers,
+			m_nerf.training.train_envmap,
+			m_nerf.cone_angle_constant,
+			m_distortion.view(),
+			sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_x_cond_y.data() : nullptr,
+			sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_y.data() : nullptr,
+			sample_image_proportional_to_error ? m_nerf.training.error_map.cdf_img.data() : nullptr,
+			m_nerf.training.error_map.cdf_resolution,
+			m_nerf.training.extra_dims_gpu.data(),
+			m_nerf_network->n_extra_dims()
+		);
 
-	if (hg_enc) {
-		hg_enc->set_max_level_gpu(m_max_level_rand_training ? max_level_compacted : nullptr);
-	}
+		if (hg_enc) {
+			hg_enc->set_max_level_gpu(m_max_level_rand_training ? max_level : nullptr);
+		}
 
-	linear_kernel(compute_loss_kernel_train_nerf, 0, stream,
-		counters.rays_per_batch,
-		m_aabb,
-		n_rays_total,
-		m_rng,
-		target_batch_size,
-		ray_counter,
-		LOSS_SCALE,
-		padded_output_width,
-		m_envmap.view(),
-		envmap_gradient,
-		m_envmap.resolution,
-		m_envmap.loss_type,
-		m_background_color.head<3>(),
-		m_color_space,
-		m_nerf.training.random_bg_color,
-		m_nerf.training.linear_colors,
-		m_nerf.training.n_images_for_training,
-		m_nerf.training.dataset.metadata_gpu.data(),
-		mlp_out,
-		counters.numsteps_counter_compacted.data(),
-		ray_indices,
-		rays_unnormalized,
-		numsteps,
-		PitchedPtr<const NerfCoordinate>((NerfCoordinate*)coords, 1, 0, extra_stride),
-		PitchedPtr<NerfCoordinate>((NerfCoordinate*)coords_compacted, 1 ,0, extra_stride),
-		dloss_dmlp_out,
-		m_nerf.training.loss_type,
-		m_nerf.training.depth_loss_type,
-		counters.loss.data(),
-		m_max_level_rand_training,
-		max_level_compacted,
-		m_nerf.rgb_activation,
-		m_nerf.density_activation,
-		m_nerf.training.snap_to_pixel_centers,
-		accumulate_error ? m_nerf.training.error_map.data.data() : nullptr,
-		sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_x_cond_y.data() : nullptr,
-		sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_y.data() : nullptr,
-		sample_image_proportional_to_error ? m_nerf.training.error_map.cdf_img.data() : nullptr,
-		m_nerf.training.error_map.resolution,
-		m_nerf.training.error_map.cdf_resolution,
-		include_sharpness_in_error ? m_nerf.training.dataset.sharpness_data.data() : nullptr,
-		m_nerf.training.dataset.sharpness_resolution,
-		m_nerf.training.sharpness_grid.data(),
-		m_nerf.density_grid.data(),
-		m_nerf.density_grid_mean.data(),
-		m_nerf.training.cam_exposure_gpu.data(),
-		m_nerf.training.optimize_exposure ? m_nerf.training.cam_exposure_gradient_gpu.data() : nullptr,
-		m_nerf.training.depth_supervision_lambda,
-		m_nerf.training.near_distance
-	);
+		GPUMatrix<float> coords_matrix((float*)coords, floats_per_coord, max_inference);
+		GPUMatrix<network_precision_t> rgbsigma_matrix(mlp_out, padded_output_width, max_inference);
+		m_network->inference_mixed_precision(stream, coords_matrix, rgbsigma_matrix, false);
+
+		if (hg_enc) {
+			hg_enc->set_max_level_gpu(m_max_level_rand_training ? max_level_compacted : nullptr);
+		}
+
+		linear_kernel(compute_loss_kernel_train_nerf, 0, stream,
+			counters.rays_per_batch,
+			m_aabb,
+			n_rays_total,
+			m_rng,
+			target_batch_size,
+			ray_counter,
+			LOSS_SCALE,
+			padded_output_width,
+			m_envmap.view(),
+			envmap_gradient,
+			m_envmap.resolution,
+			m_envmap.loss_type,
+			m_background_color.rgb,
+			m_color_space,
+			m_nerf.training.random_bg_color,
+			m_nerf.training.linear_colors,
+			m_nerf.training.n_images_for_training,
+			m_nerf.training.dataset.metadata_gpu.data(),
+			mlp_out,
+			counters.numsteps_counter_compacted.data(),
+			ray_indices,
+			rays_unnormalized,
+			numsteps,
+			PitchedPtr<const NerfCoordinate>((NerfCoordinate*)coords, 1, 0, extra_stride),
+			PitchedPtr<NerfCoordinate>((NerfCoordinate*)coords_compacted, 1 ,0, extra_stride),
+			dloss_dmlp_out,
+			m_nerf.training.loss_type,
+			m_nerf.training.depth_loss_type,
+			counters.loss.data(),
+			m_max_level_rand_training,
+			max_level_compacted,
+			m_nerf.rgb_activation,
+			m_nerf.density_activation,
+			m_nerf.training.snap_to_pixel_centers,
+			accumulate_error ? m_nerf.training.error_map.data.data() : nullptr,
+			sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_x_cond_y.data() : nullptr,
+			sample_focal_plane_proportional_to_error ? m_nerf.training.error_map.cdf_y.data() : nullptr,
+			sample_image_proportional_to_error ? m_nerf.training.error_map.cdf_img.data() : nullptr,
+			m_nerf.training.error_map.resolution,
+			m_nerf.training.error_map.cdf_resolution,
+			include_sharpness_in_error ? m_nerf.training.dataset.sharpness_data.data() : nullptr,
+			m_nerf.training.dataset.sharpness_resolution,
+			m_nerf.training.sharpness_grid.data(),
+			m_nerf.density_grid.data(),
+			m_nerf.density_grid_mean.data(),
+			m_nerf.max_cascade,
+			m_nerf.training.cam_exposure_gpu.data(),
+			m_nerf.training.optimize_exposure ? m_nerf.training.cam_exposure_gradient_gpu.data() : nullptr,
+			m_nerf.training.depth_supervision_lambda,
+			m_nerf.training.near_distance
+		);
 
 	fill_rollover_and_rescale<network_precision_t><<<n_blocks_linear(target_batch_size*padded_output_width), n_threads_linear, 0, stream>>>(
 		target_batch_size, padded_output_width, counters.numsteps_counter_compacted.data(), dloss_dmlp_out
@@ -3450,8 +3535,8 @@ void Testbed::compute_mesh_vertex_colors() {
 	}
 }
 
-GPUMemory<float> Testbed::get_density_on_grid(Vector3i res3d, const BoundingBox& aabb, const Eigen::Matrix3f& render_aabb_to_local) {
-	const uint32_t n_elements = (res3d.x()*res3d.y()*res3d.z());
+GPUMemory<float> Testbed::get_density_on_grid(ivec3 res3d, const BoundingBox& aabb, const mat3& render_aabb_to_local) {
+	const uint32_t n_elements = (res3d.x*res3d.y*res3d.z);
 	GPUMemory<float> density(n_elements);
 
 	const uint32_t batch_size = std::min(n_elements, 1u<<20);
@@ -3469,9 +3554,9 @@ GPUMemory<float> Testbed::get_density_on_grid(Vector3i res3d, const BoundingBox&
 	network_precision_t* mlp_out = std::get<1>(scratch);
 
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res3d.x(), threads.x), div_round_up((uint32_t)res3d.y(), threads.y), div_round_up((uint32_t)res3d.z(), threads.z) };
+	const dim3 blocks = { div_round_up((uint32_t)res3d.x, threads.x), div_round_up((uint32_t)res3d.y, threads.y), div_round_up((uint32_t)res3d.z, threads.z) };
 
-	BoundingBox unit_cube = BoundingBox{Vector3f::Zero(), Vector3f::Ones()};
+	BoundingBox unit_cube = BoundingBox{vec3(0.0f), vec3(1.0f)};
 	generate_grid_samples_nerf_uniform<<<blocks, threads, 0, m_stream.get()>>>(res3d, m_nerf.density_grid_ema_step, aabb, render_aabb_to_local, nerf_mode ? m_aabb : unit_cube , positions);
 
 	// Only process 1m elements at a time
@@ -3501,15 +3586,15 @@ GPUMemory<float> Testbed::get_density_on_grid(Vector3i res3d, const BoundingBox&
 	return density;
 }
 
-GPUMemory<Eigen::Array4f> Testbed::get_rgba_on_grid(Vector3i res3d, Eigen::Vector3f ray_dir, bool voxel_centers, float depth, bool density_as_alpha) {
-	const uint32_t n_elements = (res3d.x()*res3d.y()*res3d.z());
-	GPUMemory<Eigen::Array4f> rgba(n_elements);
+GPUMemory<vec4> Testbed::get_rgba_on_grid(ivec3 res3d, vec3 ray_dir, bool voxel_centers, float depth, bool density_as_alpha) {
+	const uint32_t n_elements = (res3d.x*res3d.y*res3d.z);
+	GPUMemory<vec4> rgba(n_elements);
 	GPUMemory<NerfCoordinate> positions(n_elements);
 	const uint32_t batch_size = std::min(n_elements, 1u<<20);
 
 	// generate inputs
 	const dim3 threads = { 16, 8, 1 };
-	const dim3 blocks = { div_round_up((uint32_t)res3d.x(), threads.x), div_round_up((uint32_t)res3d.y(), threads.y), div_round_up((uint32_t)res3d.z(), threads.z) };
+	const dim3 blocks = { div_round_up((uint32_t)res3d.x, threads.x), div_round_up((uint32_t)res3d.y, threads.y), div_round_up((uint32_t)res3d.z, threads.z) };
 	generate_grid_samples_nerf_uniform_dir<<<blocks, threads, 0, m_stream.get()>>>(res3d, m_nerf.density_grid_ema_step, m_render_aabb, m_render_aabb_to_local, m_aabb, ray_dir, positions.data(), voxel_centers);
 
 	// Only process 1m elements at a time
@@ -3522,15 +3607,15 @@ GPUMemory<Eigen::Array4f> Testbed::get_rgba_on_grid(Vector3i res3d, Eigen::Vecto
 		m_network->inference(m_stream.get(), positions_matrix, rgbsigma_matrix);
 
 		// convert network output to RGBA (in place)
-		linear_kernel(compute_nerf_rgba, 0, m_stream.get(), local_batch_size, rgba.data() + offset, m_nerf.rgb_activation, m_nerf.density_activation, depth, density_as_alpha);
+		linear_kernel(compute_nerf_rgba_kernel, 0, m_stream.get(), local_batch_size, rgba.data() + offset, m_nerf.rgb_activation, m_nerf.density_activation, depth, density_as_alpha);
 	}
 	return rgba;
 }
 
-int Testbed::marching_cubes(Vector3i res3d, const BoundingBox& aabb, const Matrix3f& render_aabb_to_local, float thresh) {
-	res3d.x() = next_multiple((unsigned int)res3d.x(), 16u);
-	res3d.y() = next_multiple((unsigned int)res3d.y(), 16u);
-	res3d.z() = next_multiple((unsigned int)res3d.z(), 16u);
+int Testbed::marching_cubes(ivec3 res3d, const BoundingBox& aabb, const mat3& render_aabb_to_local, float thresh) {
+	res3d.x = next_multiple((unsigned int)res3d.x, 16u);
+	res3d.y = next_multiple((unsigned int)res3d.y, 16u);
+	res3d.z = next_multiple((unsigned int)res3d.z, 16u);
 
 	if (thresh == std::numeric_limits<float>::max()) {
 		thresh = m_mesh.thresh;
@@ -3542,7 +3627,7 @@ int Testbed::marching_cubes(Vector3i res3d, const BoundingBox& aabb, const Matri
 	uint32_t n_verts = (uint32_t)m_mesh.verts.size();
 	m_mesh.verts_gradient.resize(n_verts);
 
-	m_mesh.trainable_verts = std::make_shared<TrainableBuffer<3, 1, float>>(Matrix<int, 1, 1>{(int)n_verts});
+	m_mesh.trainable_verts = std::make_shared<TrainableBuffer<3, 1, float>>(std::array<int, 1>{{(int)n_verts}});
 	m_mesh.verts_gradient.copy_from_device(m_mesh.verts); // Make sure the vertices don't get destroyed in the initialization
 
 	pcg32 rnd{m_seed};
@@ -3573,8 +3658,8 @@ int Testbed::find_best_training_view(int default_view) {
 	int bestimage = default_view;
 	float bestscore = 1000.f;
 	for (int i = 0; i < m_nerf.training.n_images_for_training; ++i) {
-		float score = (m_nerf.training.transforms[i].start.col(3) - m_camera.col(3)).norm();
-		score += 0.25f * (m_nerf.training.transforms[i].start.col(2) - m_camera.col(2)).norm();
+		float score = distance(m_nerf.training.transforms[i].start[3], m_camera[3]);
+		score += 0.25f * distance(m_nerf.training.transforms[i].start[2], m_camera[2]);
 		if (score < bestscore) {
 			bestscore = score;
 			bestimage = i;

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -18,14 +18,12 @@
 
 NGP_NAMESPACE_BEGIN
 
-using namespace std;
-
 ThreadPool::ThreadPool()
-: ThreadPool{thread::hardware_concurrency()} {}
+: ThreadPool{std::thread::hardware_concurrency()} {}
 
 ThreadPool::ThreadPool(size_t max_num_threads, bool force) {
 	if (!force) {
-		max_num_threads = min((size_t)thread::hardware_concurrency(), max_num_threads);
+		max_num_threads = std::min((size_t)std::thread::hardware_concurrency(), max_num_threads);
 	}
 	start_threads(max_num_threads);
 }
@@ -40,7 +38,7 @@ void ThreadPool::start_threads(size_t num) {
 	for (size_t i = m_threads.size(); i < m_num_threads; ++i) {
 		m_threads.emplace_back([this, i] {
 			while (true) {
-				unique_lock<mutex> lock{m_task_queue_mutex};
+				std::unique_lock<std::mutex> lock{m_task_queue_mutex};
 
 				// look for a work item
 				while (i < m_num_threads && m_task_queue.empty()) {
@@ -54,7 +52,7 @@ void ThreadPool::start_threads(size_t num) {
 					break;
 				}
 
-				function<void()> task{move(m_task_queue.front())};
+				std::function<void()> task{move(m_task_queue.front())};
 				m_task_queue.pop_front();
 
 				// Unlock the lock, so we can process the task without blocking other threads
@@ -67,10 +65,10 @@ void ThreadPool::start_threads(size_t num) {
 }
 
 void ThreadPool::shutdown_threads(size_t num) {
-	auto num_to_close = min(num, m_num_threads);
+	auto num_to_close = std::min(num, m_num_threads);
 
 	{
-		lock_guard<mutex> lock{m_task_queue_mutex};
+		std::lock_guard<std::mutex> lock{m_task_queue_mutex};
 		m_num_threads -= num_to_close;
 	}
 
@@ -91,12 +89,12 @@ void ThreadPool::set_n_threads(size_t num) {
 }
 
 void ThreadPool::wait_until_queue_completed() {
-	unique_lock<mutex> lock{m_task_queue_mutex};
+	std::unique_lock<std::mutex> lock{m_task_queue_mutex};
 	m_task_queue_completed_condition.wait(lock, [this]() { return m_task_queue.empty(); });
 }
 
 void ThreadPool::flush_queue() {
-	lock_guard<mutex> lock{m_task_queue_mutex};
+	std::lock_guard<std::mutex> lock{m_task_queue_mutex};
 	m_task_queue.clear();
 }
 

--- a/src/tinyobj_loader_wrapper.cpp
+++ b/src/tinyobj_loader_wrapper.cpp
@@ -25,11 +25,9 @@
 #include <iostream>
 #include <vector>
 
-using namespace Eigen;
-
 NGP_NAMESPACE_BEGIN
 
-std::vector<Vector3f> load_obj(const fs::path& path) {
+std::vector<vec3> load_obj(const fs::path& path) {
 	tinyobj::attrib_t attrib;
 	std::vector<tinyobj::shape_t> shapes;
 	std::vector<tinyobj::material_t> materials;
@@ -48,7 +46,7 @@ std::vector<Vector3f> load_obj(const fs::path& path) {
 		throw std::runtime_error{fmt::format("Error loading '{}': {}", path.str(), err)};
 	}
 
-	std::vector<Vector3f> result;
+	std::vector<vec3> result;
 
 	tlog::success() << "Loaded mesh \"" << path.str() << "\" file with " << shapes.size() << " shapes.";
 

--- a/src/triangle_bvh.cu
+++ b/src/triangle_bvh.cu
@@ -16,8 +16,6 @@
 #include <neural-graphics-primitives/triangle_bvh.cuh>
 #include <tiny-cuda-nn/gpu_memory.h>
 
-#include <Eigen/Dense>
-
 #include <stack>
 
 #ifdef NGP_OPTIX
@@ -40,13 +38,11 @@ namespace optix_ptx {
 }
 #endif //NGP_OPTIX
 
-using namespace Eigen;
 using namespace tcnn;
 
 NGP_NAMESPACE_BEGIN
 
 constexpr float MAX_DIST = 10.0f;
-constexpr float MAX_DIST_SQ = MAX_DIST*MAX_DIST;
 
 #ifdef NGP_OPTIX
 OptixDeviceContext g_optix;
@@ -143,10 +139,10 @@ namespace optix {
 }
 #endif //NGP_OPTIX
 
-__global__ void signed_distance_watertight_kernel(uint32_t n_elements, const Vector3f* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
-__global__ void signed_distance_raystab_kernel(uint32_t n_elements, const Vector3f* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
-__global__ void unsigned_distance_kernel(uint32_t n_elements, const Vector3f* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
-__global__ void raytrace_kernel(uint32_t n_elements, Vector3f* __restrict__ positions, Vector3f* __restrict__ directions, const TriangleBvhNode* __restrict__ nodes, const Triangle* __restrict__ triangles);
+__global__ void signed_distance_watertight_kernel(uint32_t n_elements, const vec3* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
+__global__ void signed_distance_raystab_kernel(uint32_t n_elements, const vec3* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
+__global__ void unsigned_distance_kernel(uint32_t n_elements, const vec3* __restrict__ positions, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float* __restrict__ distances, bool use_existing_distances_as_upper_bounds = false);
+__global__ void raytrace_kernel(uint32_t n_elements, vec3* __restrict__ positions, vec3* __restrict__ directions, const TriangleBvhNode* __restrict__ nodes, const Triangle* __restrict__ triangles);
 
 struct DistAndIdx {
 	float dist;
@@ -267,7 +263,7 @@ __host__ __device__ void sorting_network(T values[N]) {
 template <uint32_t BRANCHING_FACTOR>
 class TriangleBvhWithBranchingFactor : public TriangleBvh {
 public:
-	__host__ __device__ static std::pair<int, float> ray_intersect(const Vector3f& ro, const Vector3f& rd, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles) {
+	__host__ __device__ static std::pair<int, float> ray_intersect(const vec3& ro, const vec3& rd, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles) {
 		FixedIntStack query_stack;
 		query_stack.push(0);
 
@@ -295,7 +291,7 @@ public:
 
 				NGP_PRAGMA_UNROLL
 				for (uint32_t i = 0; i < BRANCHING_FACTOR; ++i) {
-					children[i] = {bvhnodes[i+first_child].bb.ray_intersect(ro, rd).x(), i+first_child};
+					children[i] = {bvhnodes[i+first_child].bb.ray_intersect(ro, rd).x, i+first_child};
 				}
 
 				sorting_network<BRANCHING_FACTOR>(children);
@@ -312,7 +308,7 @@ public:
 		return {shortest_idx, mint};
 	}
 
-	__host__ __device__ static std::pair<int, float> closest_triangle(const Vector3f& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq = MAX_DIST_SQ) {
+	__host__ __device__ static std::pair<int, float> closest_triangle(const vec3& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq) {
 		FixedIntStack query_stack;
 		query_stack.push(0);
 
@@ -364,14 +360,14 @@ public:
 	}
 
 	// Assumes that "point" is a location on a triangle
-	__host__ __device__ static Vector3f avg_normal_around_point(const Vector3f& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles) {
+	__host__ __device__ static vec3 avg_normal_around_point(const vec3& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles) {
 		FixedIntStack query_stack;
 		query_stack.push(0);
 
 		static constexpr float EPSILON = 1e-6f;
 
 		float total_weight = 0;
-		Vector3f result = Vector3f::Zero();
+		vec3 result = vec3(0.0f);
 
 		while (!query_stack.empty()) {
 			int idx = query_stack.pop();
@@ -402,30 +398,30 @@ public:
 		return result / total_weight;
 	}
 
-	__host__ __device__ static float unsigned_distance(const Vector3f& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq = MAX_DIST_SQ) {
+	__host__ __device__ static float unsigned_distance(const vec3& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq) {
 		return closest_triangle(point, bvhnodes, triangles, max_distance_sq).second;
 	}
 
-	__host__ __device__ static float signed_distance_watertight(const Vector3f& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq = MAX_DIST_SQ) {
+	__host__ __device__ static float signed_distance_watertight(const vec3& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq) {
 		auto p = closest_triangle(point, bvhnodes, triangles, max_distance_sq);
 
 		const Triangle& tri = triangles[p.first];
-		Vector3f closest_point = tri.closest_point(point);
-		Vector3f avg_normal = avg_normal_around_point(closest_point, bvhnodes, triangles);
+		vec3 closest_point = tri.closest_point(point);
+		vec3 avg_normal = avg_normal_around_point(closest_point, bvhnodes, triangles);
 
-		return std::copysignf(p.second, avg_normal.dot(point - closest_point));
+		return std::copysignf(p.second, dot(avg_normal, point - closest_point));
 	}
 
-	__host__ __device__ static float signed_distance_raystab(const Vector3f& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq = MAX_DIST_SQ, default_rng_t rng={}) {
+	__host__ __device__ static float signed_distance_raystab(const vec3& point, const TriangleBvhNode* __restrict__ bvhnodes, const Triangle* __restrict__ triangles, float max_distance_sq, default_rng_t rng={}) {
 		float distance = unsigned_distance(point, bvhnodes, triangles, max_distance_sq);
 
-		Vector2f offset = random_val_2d(rng);
+		vec2 offset = random_val_2d(rng);
 
 		static constexpr uint32_t N_STAB_RAYS = 32;
 		for (uint32_t i = 0; i < N_STAB_RAYS; ++i) {
 			// Use a Fibonacci lattice (with random offset) to regularly
 			// distribute the stab rays over the sphere.
-			Vector3f d = fibonacci_dir<N_STAB_RAYS>(i, offset);
+			vec3 d = fibonacci_dir<N_STAB_RAYS>(i, offset);
 
 			// If any of the stab rays goes outside the mesh, the SDF is positive.
 			if (ray_intersect(point, d, bvhnodes, triangles).first < 0) {
@@ -437,19 +433,19 @@ public:
 	}
 
 	// Assumes that "point" is a location on a triangle
-	Vector3f avg_normal_around_point(const Vector3f& point, const Triangle* __restrict__ triangles) const {
+	vec3 avg_normal_around_point(const vec3& point, const Triangle* __restrict__ triangles) const {
 		return avg_normal_around_point(point, m_nodes.data(), triangles);
 	}
 
-	float signed_distance(EMeshSdfMode mode, const Vector3f& point, const std::vector<Triangle>& triangles) const {
+	float signed_distance(EMeshSdfMode mode, const vec3& point, const std::vector<Triangle>& triangles) const {
 		if (mode == EMeshSdfMode::Watertight) {
-			return signed_distance_watertight(point, m_nodes.data(), triangles.data());
+			return signed_distance_watertight(point, m_nodes.data(), triangles.data(), MAX_DIST*MAX_DIST);
 		} else {
-			return signed_distance_raystab(point, m_nodes.data(), triangles.data());
+			return signed_distance_raystab(point, m_nodes.data(), triangles.data(), MAX_DIST*MAX_DIST);
 		}
 	}
 
-	void signed_distance_gpu(uint32_t n_elements, EMeshSdfMode mode, const Vector3f* gpu_positions, float* gpu_distances, const Triangle* gpu_triangles, bool use_existing_distances_as_upper_bounds, cudaStream_t stream) override {
+	void signed_distance_gpu(uint32_t n_elements, EMeshSdfMode mode, const vec3* gpu_positions, float* gpu_distances, const Triangle* gpu_triangles, bool use_existing_distances_as_upper_bounds, cudaStream_t stream) override {
 		if (mode == EMeshSdfMode::Watertight) {
 			linear_kernel(signed_distance_watertight_kernel, 0, stream,
 				n_elements,
@@ -495,7 +491,7 @@ public:
 		}
 	}
 
-	void ray_trace_gpu(uint32_t n_elements, Vector3f* gpu_positions, Vector3f* gpu_directions, const Triangle* gpu_triangles, cudaStream_t stream) override {
+	void ray_trace_gpu(uint32_t n_elements, vec3* gpu_positions, vec3* gpu_directions, const Triangle* gpu_triangles, cudaStream_t stream) override {
 #ifdef NGP_OPTIX
 		if (m_optix.available) {
 			m_optix.raytrace->invoke({gpu_positions, gpu_directions, gpu_triangles, m_optix.gas->handle()}, {n_elements, 1, 1}, stream);
@@ -575,21 +571,21 @@ public:
 					auto& child = children[i];
 
 					// Choose axis with maximum standard deviation
-					Vector3f mean = Vector3f::Zero();
+					vec3 mean = vec3(0.0f);
 					for (auto it = child.begin; it != child.end; ++it) {
 						mean += it->centroid();
 					}
 					mean /= (float)std::distance(child.begin, child.end);
 
-					Vector3f var = Vector3f::Zero();
+					vec3 var = vec3(0.0f);
 					for (auto it = child.begin; it != child.end; ++it) {
-						Vector3f diff = it->centroid() - mean;
-						var += diff.cwiseProduct(diff);
+						vec3 diff = it->centroid() - mean;
+						var += diff * diff;
 					}
 					var /= (float)std::distance(child.begin, child.end);
 
-					Vector3f::Index axis;
-					var.maxCoeff(&axis);
+					float max_val = compMax(var);
+					int axis = var.x == max_val ? 0 : (var.y == max_val ? 1 : 2);
 
 					auto m = child.begin + std::distance(child.begin, child.end)/2;
 					std::nth_element(child.begin, m, child.end, [&](const Triangle& tri1, const Triangle& tri2) { return tri1.centroid(axis) < tri2.centroid(axis); });
@@ -665,7 +661,7 @@ std::unique_ptr<TriangleBvh> TriangleBvh::make() {
 }
 
 __global__ void signed_distance_watertight_kernel(uint32_t n_elements,
-	const Vector3f* __restrict__ positions,
+	const vec3* __restrict__ positions,
 	const TriangleBvhNode* __restrict__ bvhnodes,
 	const Triangle* __restrict__ triangles,
 	float* __restrict__ distances,
@@ -680,7 +676,7 @@ __global__ void signed_distance_watertight_kernel(uint32_t n_elements,
 
 __global__ void signed_distance_raystab_kernel(
 	uint32_t n_elements,
-	const Vector3f* __restrict__ positions,
+	const vec3* __restrict__ positions,
 	const TriangleBvhNode* __restrict__ bvhnodes,
 	const Triangle* __restrict__ triangles,
 	float* __restrict__ distances,
@@ -697,7 +693,7 @@ __global__ void signed_distance_raystab_kernel(
 }
 
 __global__ void unsigned_distance_kernel(uint32_t n_elements,
-	const Vector3f* __restrict__ positions,
+	const vec3* __restrict__ positions,
 	const TriangleBvhNode* __restrict__ bvhnodes,
 	const Triangle* __restrict__ triangles,
 	float* __restrict__ distances,
@@ -710,7 +706,7 @@ __global__ void unsigned_distance_kernel(uint32_t n_elements,
 	distances[i] = TriangleBvh4::unsigned_distance(positions[i], bvhnodes, triangles, max_distance*max_distance);
 }
 
-__global__ void raytrace_kernel(uint32_t n_elements, Vector3f* __restrict__ positions, Vector3f* __restrict__ directions, const TriangleBvhNode* __restrict__ nodes, const Triangle* __restrict__ triangles) {
+__global__ void raytrace_kernel(uint32_t n_elements, vec3* __restrict__ positions, vec3* __restrict__ directions, const TriangleBvhNode* __restrict__ nodes, const Triangle* __restrict__ triangles) {
 	uint32_t i = blockIdx.x * blockDim.x + threadIdx.x;
 	if (i >= n_elements) return;
 


### PR DESCRIPTION
- improves compile time by ~3x
- makes graphics computations much simpler to read and write (syntax very close to GLSL)
- fixes occasional out of bounds memory access during training, which positively impacts PSNR (brings `--test_transforms` results back on par with the codebase from a year ago; reproduces paper results)
- updates the default NeRF config (`base.json`) to give slightly better performance & quality