### PR TITLE
Added a button to initialize camera path from training views 

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -396,6 +396,7 @@ public:
 	void last_training_view();
 	void previous_training_view();
 	void next_training_view();
+    void add_cameras_from_training_views();
 	void set_camera_to_training_view(int trainview);
 	void reset_camera();
 	bool keyboard_event();

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -396,7 +396,7 @@ public:
 	void last_training_view();
 	void previous_training_view();
 	void next_training_view();
-    void add_cameras_from_training_views();
+	void add_training_views_to_camera_path();
 	void set_camera_to_training_view(int trainview);
 	void reset_camera();
 	bool keyboard_event();

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -514,7 +514,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("screen_center", &Testbed::m_screen_center)
 		.def_readwrite("training_batch_size", &Testbed::m_training_batch_size)
 		.def("set_nerf_camera_matrix", &Testbed::set_nerf_camera_matrix)
-        .def("add_cameras_from_training_views", &Testbed::add_cameras_from_training_views)
+		.def("add_training_views_to_camera_path", &Testbed::add_training_views_to_camera_path)
 		.def("set_camera_to_training_view", &Testbed::set_camera_to_training_view)
 		.def("first_training_view", &Testbed::first_training_view)
 		.def("last_training_view", &Testbed::last_training_view)

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -514,6 +514,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_readwrite("screen_center", &Testbed::m_screen_center)
 		.def_readwrite("training_batch_size", &Testbed::m_training_batch_size)
 		.def("set_nerf_camera_matrix", &Testbed::set_nerf_camera_matrix)
+        .def("add_cameras_from_training_views", &Testbed::add_cameras_from_training_views)
 		.def("set_camera_to_training_view", &Testbed::set_camera_to_training_view)
 		.def("first_training_view", &Testbed::first_training_view)
 		.def("last_training_view", &Testbed::last_training_view)

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1397,6 +1397,10 @@ void Testbed::imgui() {
 			}
 
 			if (m_testbed_mode == ETestbedMode::Nerf) {
+				if (ImGui::Button("Add training views to camera path")) {
+					add_training_views_to_camera_path();
+				}
+
 				if (ImGui::Button("First")) {
 					first_training_view();
 				}
@@ -1742,13 +1746,6 @@ void Testbed::imgui() {
 
 	if (ImGui::Button("Go to python REPL")) {
 		m_want_repl = true;
-	}
-
-	if (m_testbed_mode == ETestbedMode::Nerf) {
-		ImGui::SameLine();
-		if (ImGui::Button("Add training views to camera path")) {
-			add_training_views_to_camera_path();
-		}
 	}
 
 	ImGui::End();

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -443,6 +443,19 @@ void Testbed::next_training_view() {
 	set_camera_to_training_view(m_nerf.training.view);
 }
 
+void Testbed::add_cameras_from_training_views() {
+    for (int i = 0; i < m_nerf.training.dataset.n_images; ++i) {
+        int n=std::max(0,int(m_camera_path.keyframes.size())-1);
+        auto camera = get_xform_given_rolling_shutter(m_nerf.training.transforms[i], m_nerf.training.dataset.metadata[i].rolling_shutter, vec2{0.5f, 0.5f}, 0.0f);
+        int j=(int)ceil(m_camera_path.play_time*(float)n+0.001f);
+        if (j>m_camera_path.keyframes.size()) j=m_camera_path.keyframes.size();
+        if (j<0) j=0;
+        m_camera_path.keyframes.insert(m_camera_path.keyframes.begin()+j, CameraKeyframe(camera, m_slice_plane_z, m_scale, fov(), m_aperture_size, m_nerf.glow_mode, m_nerf.glow_y_cutoff));
+        n=std::max(0,int(m_camera_path.keyframes.size())-1);
+        m_camera_path.play_time = n ? float(j)/float(n) : 1.f;
+    }
+}
+
 void Testbed::set_camera_to_training_view(int trainview) {
 	auto old_look_at = look_at();
 	m_camera = m_smoothed_camera = get_xform_given_rolling_shutter(m_nerf.training.transforms[trainview], m_nerf.training.dataset.metadata[trainview].rolling_shutter, vec2{0.5f, 0.5f}, 0.0f);
@@ -1730,6 +1743,13 @@ void Testbed::imgui() {
 	if (ImGui::Button("Go to python REPL")) {
 		m_want_repl = true;
 	}
+
+    if (m_testbed_mode == ETestbedMode::Nerf) {
+        ImGui::SameLine();
+        if (ImGui::Button("Add training views to camera path")) {
+            add_cameras_from_training_views();
+        }
+    }
 
 	ImGui::End();
 }

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -443,17 +443,17 @@ void Testbed::next_training_view() {
 	set_camera_to_training_view(m_nerf.training.view);
 }
 
-void Testbed::add_cameras_from_training_views() {
-    for (int i = 0; i < m_nerf.training.dataset.n_images; ++i) {
-        int n=std::max(0,int(m_camera_path.keyframes.size())-1);
-        auto camera = get_xform_given_rolling_shutter(m_nerf.training.transforms[i], m_nerf.training.dataset.metadata[i].rolling_shutter, vec2{0.5f, 0.5f}, 0.0f);
-        int j=(int)ceil(m_camera_path.play_time*(float)n+0.001f);
-        if (j>m_camera_path.keyframes.size()) j=m_camera_path.keyframes.size();
-        if (j<0) j=0;
-        m_camera_path.keyframes.insert(m_camera_path.keyframes.begin()+j, CameraKeyframe(camera, m_slice_plane_z, m_scale, fov(), m_aperture_size, m_nerf.glow_mode, m_nerf.glow_y_cutoff));
-        n=std::max(0,int(m_camera_path.keyframes.size())-1);
-        m_camera_path.play_time = n ? float(j)/float(n) : 1.f;
-    }
+void Testbed::add_training_views_to_camera_path() {
+	for (int i = 0; i < m_nerf.training.dataset.n_images; ++i) {
+		int n = std::max(0, int(m_camera_path.keyframes.size()) - 1);
+		auto camera = get_xform_given_rolling_shutter(m_nerf.training.transforms[i], m_nerf.training.dataset.metadata[i].rolling_shutter, vec2{0.5f, 0.5f}, 0.0f);
+		int j = (int) ceil(m_camera_path.play_time * (float) n + 0.001f);
+		if (j > m_camera_path.keyframes.size()) j = m_camera_path.keyframes.size();
+		if (j < 0) j = 0;
+		m_camera_path.keyframes.insert(m_camera_path.keyframes.begin() + j, CameraKeyframe(camera, m_slice_plane_z, m_scale, fov(), m_aperture_size, m_nerf.glow_mode, m_nerf.glow_y_cutoff));
+		n = std::max(0, int(m_camera_path.keyframes.size()) - 1);
+		m_camera_path.play_time = n ? float(j) / float(n) : 1.f;
+	}
 }
 
 void Testbed::set_camera_to_training_view(int trainview) {
@@ -1744,12 +1744,12 @@ void Testbed::imgui() {
 		m_want_repl = true;
 	}
 
-    if (m_testbed_mode == ETestbedMode::Nerf) {
-        ImGui::SameLine();
-        if (ImGui::Button("Add training views to camera path")) {
-            add_cameras_from_training_views();
-        }
-    }
+	if (m_testbed_mode == ETestbedMode::Nerf) {
+		ImGui::SameLine();
+		if (ImGui::Button("Add training views to camera path")) {
+			add_training_views_to_camera_path();
+		}
+	}
 
 	ImGui::End();
 }


### PR DESCRIPTION
Thanks again for your great work on this project.

I added a button to initialize camera paths from the training view camera positions.

We used it for example in our SII paper about "neural scanning" to create animations flying around objects: https://github.com/robocip-aist/sii_nerf_scans

Also it seems other people have requested this feature:
https://github.com/NVlabs/instant-ngp/discussions/506