### PR TITLE
Synchronize stream before exposure optimization

### DIFF
--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -3161,7 +3161,7 @@ void Testbed::train_nerf(uint32_t target_batch_size, bool get_loss_scalar, cudaS
 
 		if (m_nerf.training.optimize_exposure) {
 			CUDA_CHECK_THROW(cudaMemcpyAsync(m_nerf.training.cam_exposure_gradient.data(), m_nerf.training.cam_exposure_gradient_gpu.data(), m_nerf.training.cam_exposure_gradient_gpu.get_bytes(), cudaMemcpyDeviceToHost, stream));
-
+			CUDA_CHECK_THROW(cudaStreamSynchronize(stream));
 			vec3 mean_exposure = vec3(0.0f);
 
 			// Optimization step


### PR DESCRIPTION
Hello,

I found during exposure optimization there may be missing a `cudaStreamSynchronize` after copying `cam_exposure_gradient_gpu` from device to host. Here I offer a simple patch :)