### PR TITLE
Fix saving/loading LatLong and Equirectangular lens to/from snapshot

### DIFF
--- a/include/neural-graphics-primitives/json_binding.h
+++ b/include/neural-graphics-primitives/json_binding.h
@@ -180,6 +180,10 @@ inline void to_json(nlohmann::json& j, const Lens& lens) {
 		j["ftheta_p4"] = lens.params[4];
 		j["w"] = lens.params[5];
 		j["h"] = lens.params[6];
+	} else if (lens.mode == ELensMode::LatLong) {
+		j["latlong"] = true;
+	} else if (lens.mode == ELensMode::Equirectangular) {
+		j["equirectangular"] = true;
 	}
 }
 
@@ -207,6 +211,10 @@ inline void from_json(const nlohmann::json& j, Lens& lens) {
 		lens.params[4] = j.at("ftheta_p4");
 		lens.params[5] = j.at("w");
 		lens.params[6] = j.at("h");
+	} else if (j.contains("latlong")) {
+		lens.mode = ELensMode::LatLong;
+	} else if (j.contains("equirectangular")) {
+		lens.mode = ELensMode::Equirectangular;
 	} else {
 		lens.mode = ELensMode::Perspective;
 	}


### PR DESCRIPTION
Hello!

I found that the current json bingding ignores some lens types, i.e. `ELensMode::LatLong` and `ELensMode::Equirectangular`.

This may cause a bug when saving a snapshot and loading it again, the training metadata with these lens falls back to incorrect `ELensMode::Perspective`

This MR adds two json keys `"latlong"` and `"equirectangular"` to indicate the lens type, where the key name is borrowed from: https://github.com/NVlabs/instant-ngp/blob/59cd4d338471eeca2eba86174bb42edbfc4d43a1/src/nerf_loader.cu#L231