### PR TITLE
:sparkles: avoid early saturation when rendering GT depth of large scenes

### DIFF
--- a/include/neural-graphics-primitives/render_buffer.h
+++ b/include/neural-graphics-primitives/render_buffer.h
@@ -251,6 +251,7 @@ public:
 		float alpha,
 		const float* __restrict__ depth,
 		float depth_scale,
+		float max_depth,
 		const ivec2& resolution,
 		int fov_axis,
 		float zoom,

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -542,6 +542,7 @@ public:
 	bool m_render_ground_truth = false;
 	EGroundTruthRenderMode m_ground_truth_render_mode = EGroundTruthRenderMode::Shade;
 	float m_ground_truth_alpha = 1.0f;
+	float m_ground_truth_max_depth = 1.0f;
 
 	bool m_train = false;
 	bool m_training_data_available = false;

--- a/src/render_buffer.cu
+++ b/src/render_buffer.cu
@@ -434,6 +434,7 @@ __global__ void overlay_depth_kernel(
 	float alpha,
 	const float* __restrict__ depth,
 	float depth_scale,
+	float max_depth,
 	ivec2 image_resolution,
 	int fov_axis,
 	float zoom,
@@ -467,7 +468,7 @@ __global__ void overlay_depth_kernel(
 		color = {0.0f, 0.0f, 0.0f, 0.0f};
 	} else {
 		float depth_value = depth[srcidx] * depth_scale;
-		vec3 c = colormap_turbo(depth_value);
+		vec3 c = colormap_turbo(depth_value/max_depth);
 		color = {c[0], c[1], c[2], 1.0f};
 	}
 
@@ -731,6 +732,7 @@ void CudaRenderBuffer::overlay_depth(
 	float alpha,
 	const float* __restrict__ depth,
 	float depth_scale,
+	float max_depth,
 	const ivec2& image_resolution,
 	int fov_axis,
 	float zoom,
@@ -745,6 +747,7 @@ void CudaRenderBuffer::overlay_depth(
 		alpha,
 		depth,
 		depth_scale,
+		max_depth,
 		image_resolution,
 		fov_axis,
 		zoom,

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1286,6 +1286,7 @@ void Testbed::imgui() {
 
 			accum_reset |= ImGui::Combo("Groundtruth render mode", (int*)&m_ground_truth_render_mode, GroundTruthRenderModeStr);
 			accum_reset |= ImGui::SliderFloat("Groundtruth alpha", &m_ground_truth_alpha, 0.0f, 1.0f, "%.02f", ImGuiSliderFlags_AlwaysClamp);
+			accum_reset |= ImGui::SliderFloat("Groundtruth Max Depth", &m_ground_truth_max_depth, 1e-3f, 10.0f, "%.02f", ImGuiSliderFlags_AlwaysClamp);
 
 			bool lens_changed = ImGui::Checkbox("Apply lens distortion", &m_nerf.render_with_lens_distortion);
 			if (m_nerf.render_with_lens_distortion) {
@@ -4520,6 +4521,7 @@ void Testbed::render_frame_epilogue(
 					m_ground_truth_alpha,
 					metadata.depth,
 					1.0f/m_nerf.training.dataset.scale,
+					m_ground_truth_max_depth,
 					metadata.resolution,
 					m_fov_axis,
 					m_zoom,


### PR DESCRIPTION
Turbo colormap is applied on the range [0,1].
Avoid saturating depths larger than 1.0m to red by scaling the depth before applying the colormap.

![max_depth](https://github.com/NVlabs/instant-ngp/assets/35526351/dd974023-f843-46b5-92d7-fc4d01b6bf0f)
