### PR TITLE
Update base CUDA image to nvidia/cuda:12.2.0-devel-ubuntu20.04

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.2-devel-ubuntu18.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 ENV COLMAP_VERSION=3.7
 ENV CMAKE_VERSION=3.21.0


### PR DESCRIPTION
"Update base CUDA image to nvidia/cuda:12.2.0-devel-ubuntu20.04

This commit addresses a compatibility issue that arose due to the unavailability of the previously used base image nvidia/cuda:10.2-devel-ubuntu18.04. The Docker pull for the 10.2 version has failed with an 'unknown manifest' error, indicating that the image is no longer accessible on Docker Hub.

To resolve this, the base image has been updated to nvidia/cuda:12.2.0-devel-ubuntu20.04, which is a newer version. This change ensures continued support and alignment with the available CUDA images by Nvidia.

Please test this updated configuration to ensure that it functions as expected with the new base image.