### PR TITLE
CMake: corrections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,10 @@ if (APPLE)
 endif()
 
 if (MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D_CRT_SECURE_NO_WARNINGS")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP24")
+	add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:_CRT_SECURE_NO_WARNINGS>")
+	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/MP24>")
 else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-fPIC>")
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
@@ -211,8 +211,8 @@ list(APPEND NGP_INCLUDE_DIRECTORIES
 
 find_package(OpenMP)
 if (OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+	add_compile_options("$<$<COMPILE_LANGUAGE:C>:${OpenMP_C_FLAGS}>")
+	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>")
 endif()
 
 if (NGP_BUILD_WITH_OPTIX)


### PR DESCRIPTION
* to set default build type, it must be done before `project()`
* use simpler `list(APPEND` to avoid typos
* use generator expressions rather than CMAKE_C_FLAGS
* correct use of definitions instead of options