### PR TITLE
Fix compute_and_save_png_slices binding default parameter value to match parameter type

### DIFF
--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -449,7 +449,7 @@ PYBIND11_MODULE(pyngp, m) {
 		.def_property("loop_animation", &Testbed::loop_animation, &Testbed::set_loop_animation)
 		.def("compute_and_save_png_slices", &Testbed::compute_and_save_png_slices,
 			py::arg("filename"),
-			py::arg("resolution") = ivec3(256),
+			py::arg("resolution") = 256,
 			py::arg("aabb") = BoundingBox{},
 			py::arg("thresh") = std::numeric_limits<float>::max(),
 			py::arg("density_range") = 4.f,


### PR DESCRIPTION
In the Python bindings file `python_api.cu`, the binding for `compute_and_save_png_slices` has a mistake. The binding contains `py::arg("resolution") = ivec3(256)` which sets the default value of this argument to a value of type `ivec3`. However, `compute_and_save_png_slices` has the following function declaration in `testbed.h`

```
ivec3 compute_and_save_png_slices(const fs::path& filename, int res, BoundingBox aabb = {}, float thresh = 2.5f, float density_range = 4.f, bool flip_y_and_z_axes = false);
```

This reveals that the correct type of `res` is in fact `int` for this function, rather than `ivec3`.

This can cause some confusion and errors. For example, if arguments of incorrect type are passed to the binding, the following error is thrown: 

```
TypeError: compute_and_save_png_slices(): incompatible function arguments. The following argument types are supported:
    1. (self: pyngp.Testbed, filename: pyngp.path, resolution: int = array([256, 256, 256]), aabb: pyngp.BoundingBox = <pyngp.BoundingBox object at 0x0000029235215F70>, thresh: float = 3.4028234663852886e+38, density_range: float = 4.0, flip_y_and_z_axes: bool = False) -> vec
```

This could make it seem that the type of `resolution` is an array, when in fact it is a scalar.

To resolve this, I request changing the default value in the binding definition from `ivec3(256)` to `256`.