### PR TITLE
Fix nerfcapture2nerf.py to allow to run it without depth info

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -728,6 +728,7 @@ public:
 
 #ifdef NGP_PYTHON
 			void set_image(int frame_idx, pybind11::array_t<float> img, pybind11::array_t<float> depth_img, float depth_scale);
+			void set_image_no_depth(int frame_idx, pybind11::array_t<float> img);
 #endif
 
 			void reset_camera_extrinsics();

--- a/scripts/nerfcapture2nerf.py
+++ b/scripts/nerfcapture2nerf.py
@@ -70,7 +70,10 @@ dds_config = """<?xml version="1.0" encoding="UTF-8" ?> \
 # ==================================================================================================
 
 def set_frame(testbed, frame_idx: int, rgb: np.ndarray, depth: np.ndarray, depth_scale: float, X_WV: np.ndarray, fx: float, fy: float, cx: float, cy: float):
-	testbed.nerf.training.set_image(frame_idx = frame_idx, img=rgb, depth_img=depth, depth_scale=depth_scale*testbed.nerf.training.dataset.scale)
+	if depth != None:
+		testbed.nerf.training.set_image(frame_idx = frame_idx, img=rgb, depth_img=depth, depth_scale=depth_scale*testbed.nerf.training.dataset.scale)
+	else:
+		testbed.nerf.training.set_image_no_depth(frame_idx = frame_idx, img=rgb)
 	testbed.nerf.training.set_camera_extrinsics(frame_idx=frame_idx, camera_to_world=X_WV)
 	testbed.nerf.training.set_camera_intrinsics(frame_idx=frame_idx, fx=fx, fy=fy, cx=cx, cy=cy)
 

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -62,6 +62,24 @@ void Testbed::Nerf::Training::set_image(int frame_idx, pybind11::array_t<float> 
 	dataset.set_training_image(frame_idx, {(int)img_buf.shape[1], (int)img_buf.shape[0]}, (const void*)img_buf.ptr, (const float*)depth_buf.ptr, depth_scale, false, EImageDataType::Float, EDepthDataType::Float);
 }
 
+void Testbed::Nerf::Training::set_image_no_depth(int frame_idx, pybind11::array_t<float> img) {
+	if (frame_idx < 0 || frame_idx >= dataset.n_images) {
+		throw std::runtime_error{"Invalid frame index"};
+	}
+
+	py::buffer_info img_buf = img.request();
+
+	if (img_buf.ndim != 3) {
+		throw std::runtime_error{"image should be (H,W,C) where C=4"};
+	}
+
+	if (img_buf.shape[2] != 4) {
+		throw std::runtime_error{"image should be (H,W,C) where C=4"};
+	}
+
+	dataset.set_training_image(frame_idx, {(int)img_buf.shape[1], (int)img_buf.shape[0]}, (const void*)img_buf.ptr, nullptr, -1.0, false, EImageDataType::Float, EDepthDataType::Float);
+}
+
 void Testbed::override_sdf_training_data(py::array_t<float> points, py::array_t<float> distances) {
 	py::buffer_info points_buf = points.request();
 	py::buffer_info distances_buf = distances.request();


### PR DESCRIPTION
As written in `pybind` [issue](https://github.com/pybind/pybind11/issues/1953), when passing `None` to C++ function, `numpy` actually passes `NaN`. This leads to access violation as `(const float*)depth_buf.ptr` in `void set_image(int frame_idx, pybind11::array_t<float> img, pybind11::array_t<float> depth_img, float depth_scale)` is not `nullptr`, while being empty.
Other solution would be to make `void set_image(int frame_idx, pybind11::array_t<float> img, pybind11::array_t<float> depth_img, float depth_scale)` argument `depth_img` type `std::optional<pybind11::array_t<float>>`. This would lead to no code duplication, however requires C++17.