### PR TITLE
#1590 fix gui not respecting color space option in testbed

### DIFF
--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -885,7 +885,7 @@ public:
 	} m_volume;
 
 	float m_camera_velocity = 1.0f;
-	EColorSpace m_color_space = EColorSpace::Linear;
+	EColorSpace m_color_space = EColorSpace::SRGB;
 	ETonemapCurve m_tonemap_curve = ETonemapCurve::Identity;
 	bool m_dlss = false;
 	std::shared_ptr<IDlssProvider> m_dlss_provider;

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -2918,7 +2918,8 @@ void Testbed::train_and_render(bool skip_rendering) {
 				futures[i].get();
 			}
 
-			render_frame_epilogue(synced_streams.get(i), view.camera0, view.prev_camera, view.screen_center, view.relative_focal_length, view.foveation, view.prev_foveation, *view.render_buffer, true);
+			bool to_srgb = (m_color_space == EColorSpace::SRGB);
+			render_frame_epilogue(synced_streams.get(i), view.camera0, view.prev_camera, view.screen_center, view.relative_focal_length, view.foveation, view.prev_foveation, *view.render_buffer, to_srgb);
 			view.prev_camera = view.camera0;
 			view.prev_foveation = view.foveation;
 		}


### PR DESCRIPTION
Addresses #1590 

- Allows for changing of color space through GUI as intended.
- Changes default color space to SRGB to maintain consistency with previous versions of Instant-NGP (this does not affect python bindings as color space is defined per-call)