### PR TITLE
Radiance Field Loss / Many worlds

### DIFF
--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -38,6 +38,13 @@ using namespace tcnn;
 
 namespace ngp {
 
+enum class ETrainMode : int {
+	NeRF,
+	RFL,
+	RFLrelax,
+};
+static constexpr const char* TrainModeStr = "NeRF\0RFL\0RFLrelax\0\0";
+
 enum class EMeshRenderMode : int {
 	Off,
 	VertexColors,

--- a/include/neural-graphics-primitives/common.h
+++ b/include/neural-graphics-primitives/common.h
@@ -38,12 +38,18 @@ using namespace tcnn;
 
 namespace ngp {
 
+// Training modes.
+// - NeRF: Standard volumetric reconstruction approach
+// - RFL (Radiance Field Loss): Promotes surface-like representations
+// - RFL-Relaxed: Hybrid approach that maintains NeRF-like volumetric properties while
+//   encouraging surface formation, resulting in faster rendering
+// For technical details, see: https://rgl.epfl.ch/publications/Zhang2025Radiance
 enum class ETrainMode : int {
-	NeRF,
-	RFL,
-	RFLrelax,
+	Nerf,
+	Rfl,
+	RflRelax,
 };
-static constexpr const char* TrainModeStr = "NeRF\0RFL\0RFLrelax\0\0";
+static constexpr const char* TrainModeStr = "Nerf\0Rfl\0RflRelax\0\0";
 
 enum class EMeshRenderMode : int {
 	Off,

--- a/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
+++ b/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
@@ -79,7 +79,8 @@ __global__ void train_nerf(
 	float near_distance,
 
 	uint32_t training_step,
-	ETrainMode training_mode
+	ETrainMode training_mode,
+	uint32_t rfl_warmup_steps
 ) {
 	const uint32_t i = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -382,7 +383,7 @@ __global__ void train_nerf(
 
 		vec3 dloss_by_drgb;
 		float dloss_by_dmlp;
-		if (training_mode == ETrainMode::Rfl && training_step < 1000) {
+		if (training_mode == ETrainMode::Rfl && training_step < rfl_warmup_steps) {
 			training_mode = ETrainMode::Nerf; // Warm up training
 		}
 		if (training_mode == ETrainMode::Rfl) {

--- a/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
+++ b/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
@@ -383,7 +383,7 @@ __global__ void train_nerf(
 		vec3 dloss_by_drgb;
 		float dloss_by_dmlp;
 		if (training_step < 500) {
-			training_mode = ETrainMode::NeRF; // Warm up training (about 3 seconds)
+			training_mode = ETrainMode::NeRF; // Warm up training (seconds)
 		}
 		if (training_mode == ETrainMode::RFL) {
 			// Radiance field loss
@@ -394,8 +394,8 @@ __global__ void train_nerf(
 				dt * sum(T * local_lg.loss - (loss_bg - loss_bg2) + depth_supervision)
 			);
 		} else if (training_mode == ETrainMode::RFLrelax) {
-			// Radiance field loss with relaxation
-			// Different from the relaxation in the paper, but works well in practice
+			// A variant of radiance field loss relaxation.
+			// This is different from the relaxation in the paper, but is much simpler and also promotes surfaces.
 			const vec3 rgb_bg = suffix / fmaxf(1e-6f, T);
 			const vec3 rgb_lerp = (1 - alpha) * rgb_bg + alpha * rgb;
 			LossAndGradient local_lg = loss_and_gradient(rgbtarget, rgb_lerp, loss_type);

--- a/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
+++ b/include/neural-graphics-primitives/fused_kernels/train_nerf.cuh
@@ -382,10 +382,10 @@ __global__ void train_nerf(
 
 		vec3 dloss_by_drgb;
 		float dloss_by_dmlp;
-		if (training_step < 500) {
-			training_mode = ETrainMode::NeRF; // Warm up training (seconds)
+		if (training_mode == ETrainMode::Rfl && training_step < 1000) {
+			training_mode = ETrainMode::Nerf; // Warm up training
 		}
-		if (training_mode == ETrainMode::RFL) {
+		if (training_mode == ETrainMode::Rfl) {
 			// Radiance field loss
 			LossAndGradient local_lg = loss_and_gradient(rgbtarget, rgb, loss_type);
 			loss_bg2 += weight * local_lg.loss;
@@ -393,8 +393,8 @@ __global__ void train_nerf(
 			dloss_by_dmlp = density_derivative * (
 				dt * sum(T * local_lg.loss - (loss_bg - loss_bg2) + depth_supervision)
 			);
-		} else if (training_mode == ETrainMode::RFLrelax) {
-			// A variant of radiance field loss relaxation.
+		} else if (training_mode == ETrainMode::RflRelax) {
+			// In-between volume reconstruction and surface reconstruction.
 			// This is different from the relaxation in the paper, but is much simpler and also promotes surfaces.
 			const vec3 rgb_bg = suffix / fmaxf(1e-6f, T);
 			const vec3 rgb_lerp = (1 - alpha) * rgb_bg + alpha * rgb;

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -819,6 +819,8 @@ public:
 			default_rng_t density_grid_rng;
 			int view = 0;
 
+			ETrainMode train_mode = ETrainMode::NeRF;
+
 			float depth_supervision_lambda = 0.f;
 
 			GPUMemory<float> sharpness_grid;
@@ -879,6 +881,9 @@ public:
 		float sharpen = 0.f;
 
 		float cone_angle_constant = 1.f / 256.f;
+
+		bool surface_rendering = false;
+		float surface_rendering_threshold = 0.5f;
 
 		bool visualize_cameras = false;
 

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -819,7 +819,7 @@ public:
 			default_rng_t density_grid_rng;
 			int view = 0;
 
-			ETrainMode train_mode = ETrainMode::NeRF;
+			ETrainMode train_mode = ETrainMode::Nerf;
 
 			float depth_supervision_lambda = 0.f;
 

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -820,6 +820,7 @@ public:
 			int view = 0;
 
 			ETrainMode train_mode = ETrainMode::RflRelax;
+			int rfl_warmup_steps = 1000;
 
 			float depth_supervision_lambda = 0.f;
 

--- a/include/neural-graphics-primitives/testbed.h
+++ b/include/neural-graphics-primitives/testbed.h
@@ -819,7 +819,7 @@ public:
 			default_rng_t density_grid_rng;
 			int view = 0;
 
-			ETrainMode train_mode = ETrainMode::Nerf;
+			ETrainMode train_mode = ETrainMode::RflRelax;
 
 			float depth_supervision_lambda = 0.f;
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -40,6 +40,9 @@ def parse_args():
 	parser.add_argument("--test_transforms", default="", help="Path to a nerf style transforms json from which we will compute PSNR.")
 	parser.add_argument("--near_distance", default=-1, type=float, help="Set the distance from the camera at which training rays start for nerf. <0 means use ngp default")
 	parser.add_argument("--exposure", default=0.0, type=float, help="Controls the brightness of the image. Positive numbers increase brightness, negative numbers decrease it.")
+	parser.add_argument("--train_mode", default="", type=str, help="The training mode to use. Can be 'nerf', 'rfl', 'rfl_relax'. If not specified, the default mode will be used.")
+	parser.add_argument("--rfl_warmup_steps", type=int, default=1000, help="Number of steps to train in NeRF mode before switching to RFL mode. Default is 1000. Only used if --train_mode is set to 'rfl'.")
+	parser.add_argument("--no_rflrelax_training_schedule", action="store_true", help="Disable RFL training schedule for RflRelax mode (active between steps 15k-30k).")
 
 	parser.add_argument("--screenshot_transforms", default="", help="Path to a nerf style transforms.json from which to save screenshots.")
 	parser.add_argument("--screenshot_frames", nargs="*", help="Which frame(s) to take screenshots of.")
@@ -146,6 +149,17 @@ if __name__ == "__main__":
 		print("NeRF training ray near_distance ", args.near_distance)
 		testbed.nerf.training.near_distance = args.near_distance
 
+	if args.train_mode:
+		if args.train_mode.lower() == "nerf":
+			testbed.nerf.training.train_mode = ngp.TrainMode.Nerf
+		elif args.train_mode.lower() == "rfl":
+			testbed.nerf.training.train_mode = ngp.TrainMode.Rfl
+		elif args.train_mode.lower() == "rfl_relax" or args.train_mode.lower() == "rflrelax":
+			testbed.nerf.training.train_mode = ngp.TrainMode.RflRelax
+		else:
+			raise ValueError(f"Unknown train mode: {args.train_mode}")
+	testbed.nerf.training.rfl_warmup_steps = args.rfl_warmup_steps
+
 	if args.nerf_compatibility:
 		print(f"NeRF compatibility mode enabled")
 
@@ -167,6 +181,9 @@ if __name__ == "__main__":
 		# Match nerf paper behaviour and train on a fixed bg.
 		testbed.nerf.training.random_bg_color = False
 
+		# Ensure that the training mode is set to NeRF.
+		testbed.nerf.training.train_mode = ngp.TrainMode.Nerf
+
 	old_training_step = 0
 	n_steps = args.n_steps
 
@@ -176,6 +193,7 @@ if __name__ == "__main__":
 	if n_steps < 0 and (not args.load_snapshot or args.gui):
 		n_steps = 35000
 
+	original_train_mode = ngp.TrainMode(testbed.nerf.training.train_mode)
 	tqdm_last_update = 0
 	if n_steps > 0:
 		with tqdm(desc="Training", total=n_steps, unit="steps") as t:
@@ -193,6 +211,16 @@ if __name__ == "__main__":
 				if testbed.training_step < old_training_step or old_training_step == 0:
 					old_training_step = 0
 					t.reset()
+
+				# Rfl-relax training schedule
+				progress_fraction = float(testbed.training_step) / n_steps
+				if (original_train_mode == ngp.TrainMode.RflRelax and
+				    not args.no_rflrelax_training_schedule):
+					# By default only enable RflRelax mode between 15k and 30k steps
+					if 3/7 <= progress_fraction < 6/7:
+						testbed.nerf.training.train_mode = ngp.TrainMode.RflRelax
+					else:
+						testbed.nerf.training.train_mode = ngp.TrainMode.Nerf
 
 				now = time.monotonic()
 				if now - tqdm_last_update > 0.1:

--- a/src/nerf_loader.cu
+++ b/src/nerf_loader.cu
@@ -441,6 +441,10 @@ NerfDataset load_nerf(const std::vector<fs::path>& jsonpaths, float sharpen_amou
 			result.from_mitsuba = true;
 		}
 
+		if (json.contains("from_mitsuba")) {
+  		    result.from_mitsuba = bool(json["from_mitsuba"]);
+  		}
+
 		if (json.contains("fix_premult")) {
 			fix_premult = (bool)json["fix_premult"];
 		}

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -799,6 +799,8 @@ PYBIND11_MODULE(pyngp, m) {
 		//.def_readonly("focal_lengths", &Testbed::Nerf::Training::focal_lengths) // use training.dataset.metadata instead
 		.def_readwrite("near_distance", &Testbed::Nerf::Training::near_distance)
 		.def_readwrite("density_grid_decay", &Testbed::Nerf::Training::density_grid_decay)
+		.def_readwrite("train_mode", &Testbed::Nerf::Training::train_mode)
+		.def_readwrite("rfl_warmup_steps", &Testbed::Nerf::Training::rfl_warmup_steps)
 		.def_readwrite("extrinsic_l2_reg", &Testbed::Nerf::Training::extrinsic_l2_reg)
 		.def_readwrite("extrinsic_learning_rate", &Testbed::Nerf::Training::extrinsic_learning_rate)
 		.def_readwrite("intrinsic_l2_reg", &Testbed::Nerf::Training::intrinsic_l2_reg)

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -309,9 +309,9 @@ PYBIND11_MODULE(pyngp, m) {
 	m.def("free_temporary_memory", &free_all_gpu_memory_arenas);
 
 	py::enum_<ETrainMode>(m, "TrainMode")
-		.value("NeRF", ETrainMode::NeRF)
-		.value("RFL", ETrainMode::RFL)
-		.value("RFLrelax", ETrainMode::RFLrelax)
+		.value("Nerf", ETrainMode::Nerf)
+		.value("Rfl", ETrainMode::Rfl)
+		.value("RflRelax", ETrainMode::RflRelax)
 		.export_values();
 
 	py::enum_<ETestbedMode>(m, "TestbedMode")

--- a/src/python_api.cu
+++ b/src/python_api.cu
@@ -308,6 +308,12 @@ PYBIND11_MODULE(pyngp, m) {
 
 	m.def("free_temporary_memory", &free_all_gpu_memory_arenas);
 
+	py::enum_<ETrainMode>(m, "TrainMode")
+		.value("NeRF", ETrainMode::NeRF)
+		.value("RFL", ETrainMode::RFL)
+		.value("RFLrelax", ETrainMode::RFLrelax)
+		.export_values();
+
 	py::enum_<ETestbedMode>(m, "TestbedMode")
 		.value("Nerf", ETestbedMode::Nerf)
 		.value("Sdf", ETestbedMode::Sdf)

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1117,8 +1117,11 @@ void Testbed::imgui() {
 		if (m_testbed_mode == ETestbedMode::Nerf) {
 			ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.4f);
 			if (ImGui::Combo("Train mode", (int*)&m_nerf.training.train_mode, TrainModeStr)) {
-				if (m_nerf.training.train_mode != ETrainMode::RFL)
+				if (m_nerf.training.train_mode == ETrainMode::Rfl) {
+					m_nerf.surface_rendering = true;
+				} else {
 					m_nerf.surface_rendering = false;
+				}
 			}
 			ImGui::PopItemWidth();
 			ImGui::SameLine();
@@ -2261,6 +2264,11 @@ bool Testbed::keyboard_event() {
 		if (shift) {
 			if (ImGui::IsKeyPressed(c[idx])) {
 				m_nerf.training.train_mode = (ETrainMode)idx;
+				if (m_nerf.training.train_mode == ETrainMode::Rfl) {
+					m_nerf.surface_rendering = true;
+				} else {
+					m_nerf.surface_rendering = false;
+				}
 			}
 		} else {
 			if (ImGui::IsKeyPressed(c[idx])) {

--- a/src/testbed.cu
+++ b/src/testbed.cu
@@ -1115,6 +1115,21 @@ void Testbed::imgui() {
 		ImGui::SameLine();
 		ImGui::Checkbox("rand levels", &m_max_level_rand_training);
 		if (m_testbed_mode == ETestbedMode::Nerf) {
+			ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.4f);
+			if (ImGui::Combo("Train mode", (int*)&m_nerf.training.train_mode, TrainModeStr)) {
+				if (m_nerf.training.train_mode != ETrainMode::RFL)
+					m_nerf.surface_rendering = false;
+			}
+			ImGui::PopItemWidth();
+			ImGui::SameLine();
+			ImGui::Checkbox("Surface rendering", &m_nerf.surface_rendering);
+
+			if (m_nerf.surface_rendering) {
+				ImGui::PushItemWidth(ImGui::GetWindowWidth() * 0.2f);
+				ImGui::SliderFloat("Surface alpha thres", &m_nerf.surface_rendering_threshold, 0.0f, 1.0f);
+				ImGui::PopItemWidth();
+			}
+
 			ImGui::Checkbox("envmap", &m_nerf.training.train_envmap);
 			ImGui::SameLine();
 			ImGui::Checkbox("extrinsics", &m_nerf.training.optimize_extrinsics);
@@ -2238,16 +2253,22 @@ bool Testbed::keyboard_event() {
 		m_imgui.show = !m_imgui.show;
 	}
 
-	for (int idx = 0; idx < std::min((int)ERenderMode::NumRenderModes, 10); ++idx) {
-		char c[] = {"1234567890"};
-		if (ImGui::IsKeyPressed(c[idx])) {
-			m_render_mode = (ERenderMode)idx;
-			reset_accumulation();
-		}
-	}
-
 	bool ctrl = ImGui::GetIO().KeyCtrl;
 	bool shift = ImGui::GetIO().KeyShift;
+
+	for (int idx = 0; idx < std::min((int)ERenderMode::NumRenderModes, 10); ++idx) {
+		char c[] = {"1234567890"};
+		if (shift) {
+			if (ImGui::IsKeyPressed(c[idx])) {
+				m_nerf.training.train_mode = (ETrainMode)idx;
+			}
+		} else {
+			if (ImGui::IsKeyPressed(c[idx])) {
+				m_render_mode = (ERenderMode)idx;
+				reset_accumulation();
+			}
+		}
+	}
 
 	if (ImGui::IsKeyPressed('Z')) {
 		m_camera_path.m_gizmo_op = ImGuizmo::TRANSLATE;

--- a/src/testbed_nerf.cu
+++ b/src/testbed_nerf.cu
@@ -3087,11 +3087,7 @@ void Testbed::train_nerf_step(uint32_t target_batch_size, Testbed::NerfCounters&
 
 	//  TODO: the below fused kernel is actually slower than the unfused alternative for NeRF training.
 	//        look into optimizing it until it is faster.
-	if (m_jit_fusion &&
-		(m_nerf.training.train_mode == ETrainMode::Rfl ||
-		 (m_nerf.training.train_mode == ETrainMode::RflRelax &&
-		  m_training_step >= 15000 &&
-		  m_training_step < 30000))) {
+	if (m_jit_fusion && (m_nerf.training.train_mode != ETrainMode::Nerf)) {
 		// JIT training, supports Nerf/Rfl/RflRelax training mode. But for pure
 		// NeRF training, it is faster to use the unfused kernel.
 		auto jit_guard = m_nerf_network->jit_guard(stream, false);
@@ -3179,7 +3175,8 @@ void Testbed::train_nerf_step(uint32_t target_batch_size, Testbed::NerfCounters&
 				m_nerf.training.depth_supervision_lambda,
 				m_nerf.training.near_distance,
 				m_training_step,
-				m_nerf.training.train_mode
+				m_nerf.training.train_mode,
+				m_nerf.training.rfl_warmup_steps
 			);
 
 			CUDA_CHECK_THROW(cudaMemcpyAsync(


### PR DESCRIPTION
This PR introduces new training modes that promote [radiance surface](https://rgl.epfl.ch/publications/Zhang2025Radiance) representations.
For research code used in the paper, please check [this repo](https://github.com/ziyi-zhang/INGP-RFL).

This PR should not change any existing behavior unless users explicitly enable the new training modes.

## New features
[x] Add RFL and a relaxed variant in JIT training mode.
[x] Support surface rendering in JIT rendering mode.
[x] _Non-JIT mode RFL training will not be supported as it is significantly slower._

## Performance
- Rendering FPS is significantly improved---about 2× faster. This applies both for RFL training, and when post-processing a converged NeRF scene with RFL for 500 iterations.
- Training speed with default batch size (2^18):
    - With NeRF training: INGP launches ~5k rays per iteration, underutilizing the GPU in JIT mode and causing a ~80% slowdown compared to non-JIT (numbers vary a lot depending on the scene).
    - With RFL training: INGP launches up to 30k rays per iteration. The increased ray count does not lead to a notable increase in iteration time---thanks to the new loop-based megakernel implementation. At this ray count, the non-JIT version becomes ~60% slower.