### PR TITLE
Fix KeyError in run.py when transform_matrix_start is missing

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -282,7 +282,14 @@ if __name__ == "__main__":
 		print(args.screenshot_frames)
 		for idx in args.screenshot_frames:
 			f = ref_transforms["frames"][int(idx)]
-			cam_matrix = f.get("transform_matrix", f["transform_matrix_start"])
+
+			if 'transform_matrix' in f:
+				cam_matrix = f['transform_matrix']
+			elif 'transform_matrix_start' in f:
+				cam_matrix = f['transform_matrix_start']
+			else:
+				raise KeyError("Missing both 'transform_matrix' and 'transform_matrix_start'")
+			
 			testbed.set_nerf_camera_matrix(np.matrix(cam_matrix)[:-1,:])
 			outname = os.path.join(args.screenshot_dir, os.path.basename(f["file_path"]))
 


### PR DESCRIPTION
This PR fixes a `KeyError` in `scripts/run.py` when using a `transforms.json` file that only includes `"transform_matrix"` (as is common in OpenCV-style datasets).

The original line:

```python
cam_matrix = f.get("transform_matrix", f["transform_matrix_start"])
```

Evaluates the fallback even when "transform_matrix" is present, causing a runtime error if "transform_matrix_start" is missing.

This PR should ensures compatibility with more datasets and avoids unnecessary crashes.

Previously attempted in #1421 but never merged.