### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Instant Neural Graphics Primitives ![](https://github.com/NVlabs/instant-ngp/workflows/CI/badge.svg)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NVlabs/instant-ngp)
 
 <img src="docs/assets_readme/fox.gif" height="342"/> <img src="docs/assets_readme/robot5.gif" height="342"/>
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/instant-ngp) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.